### PR TITLE
Gofer, remove unused log levels from CLI options

### DIFF
--- a/pkg/log/logrus/flag/logger.go
+++ b/pkg/log/logrus/flag/logger.go
@@ -84,6 +84,9 @@ func (f *verbosityFlag) Set(v string) (err error) {
 func (f *verbosityFlag) Type() string {
 	var s string
 	for _, l := range logrus.AllLevels {
+		if l == logrus.TraceLevel || l == logrus.FatalLevel { // Don't display unused log levels
+			continue
+		}
 		if len(s) > 0 {
 			s += "|"
 		}


### PR DESCRIPTION
https://discord.com/channels/850545426251251732/850545786621395005/938193306091921448

All logrus log levels are displayed in the help options, but they are not all used. Removes `trace`:

```
./bin/gofer

Gofer is a CLI interface for the Gofer Go Library.

Flags:
  -v, --log.verbosity panic|fatal|error|warning|info|debug   verbosity level (default warning)
...
```

(^ Also verified that the above were all in use somewhere in the code.)