### PR TITLE
sc641, adds an aggregate timeout over endpoints

### DIFF
--- a/cmd/rpc-splitter/README.md
+++ b/cmd/rpc-splitter/README.md
@@ -83,10 +83,10 @@ Flags:
   -l, --listen string                                  listen address (default "127.0.0.1:8545")
       --log.format text|json                           log format (default text)
   -v, --log.verbosity panic|error|warning|info|debug   verbosity level (default warning)
+  -t, --timeout int                                    Set request timeout (in seconds) for all RPC calls (default 10)
       --version                                        version for rpc-splitter
 
 Use "rpc-splitter [command] --help" for more information about a command.
-
 ```
 
 ## License

--- a/cmd/rpc-splitter/cmd.go
+++ b/cmd/rpc-splitter/cmd.go
@@ -23,9 +23,10 @@ import (
 )
 
 type options struct {
-	Listen     string
-	EnableCORS bool
-	EthRPCURLs []string
+	Listen            string
+	EnableCORS        bool
+	RequestTimeoutSec int
+	EthRPCURLs        []string
 	flag.LoggerFlag
 }
 
@@ -53,6 +54,12 @@ func NewRootCommand(opts *options) *cobra.Command {
 		"c",
 		false,
 		"enables CORS requests for all origins",
+	)
+	rootCmd.PersistentFlags().IntVarP(
+		&opts.RequestTimeoutSec,
+		"timeout", "t",
+		10,
+		"Set request timeout (in seconds) for all RPC endpoints",
 	)
 	rootCmd.PersistentFlags().StringSliceVar(
 		&opts.EthRPCURLs,

--- a/cmd/rpc-splitter/cmd_run.go
+++ b/cmd/rpc-splitter/cmd_run.go
@@ -40,8 +40,7 @@ func NewRunCmd(opts *options) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 			log := opts.Logger()
-
-			handler, err := rpcsplitter.NewHandler(opts.EthRPCURLs, log)
+			handler, err := rpcsplitter.NewHandler(opts.EthRPCURLs, opts.RequestTimeoutSec, log)
 			if err != nil {
 				return err
 			}

--- a/internal/config/ethereum/ethereum.go
+++ b/internal/config/ethereum/ethereum.go
@@ -32,6 +32,7 @@ import (
 )
 
 const splitterVirtualHost = "makerdao-splitter"
+const splitterDefaultTimeoutSec = 9 // This is lower than the "upper level" default of 10s, i.e. within Gofer
 
 var ethClientFactory = func(endpoints []string) (geth.EthClient, error) {
 	switch len(endpoints) {
@@ -40,8 +41,9 @@ var ethClientFactory = func(endpoints []string) (geth.EthClient, error) {
 	case 1:
 		return ethclient.Dial(endpoints[0])
 	default:
+		// TODO(jamesr): get splitter timeout from config, not hard coded
 		// TODO: pass logger
-		splitter, err := rpcsplitter.NewTransport(endpoints, splitterVirtualHost, nil, null.New())
+		splitter, err := rpcsplitter.NewTransport(endpoints, splitterDefaultTimeoutSec, splitterVirtualHost, nil, null.New())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/rpcsplitter/mock_test.go
+++ b/internal/rpcsplitter/mock_test.go
@@ -17,6 +17,7 @@ package rpcsplitter
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -70,7 +71,7 @@ func (c *mockClient) mockCall(result interface{}, method string, params ...inter
 	})
 }
 
-func (c *mockClient) Call(result interface{}, method string, params ...interface{}) error {
+func (c *mockClient) CallContext(ctx context.Context, result interface{}, method string, params ...interface{}) error {
 	if c.currCall >= len(c.calls) {
 		require.Fail(c.t, "unexpected call")
 	}
@@ -130,7 +131,7 @@ func (t *handlerTester) expectedError(msg string) *handlerTester {
 
 func (t *handlerTester) test() {
 	// Prepare handler.
-	h, err := newHandlerWithClients(t.clients, null.New())
+	h, err := newHandlerWithClients(t.clients, 10, null.New())
 	require.NoError(t.t, err)
 
 	// Prepare request.

--- a/internal/rpcsplitter/transport.go
+++ b/internal/rpcsplitter/transport.go
@@ -33,8 +33,10 @@ type Transport struct {
 }
 
 // NewTransport returns a new instance of Transport.
-func NewTransport(endpoints []string, vhost string, transport http.RoundTripper, log log.Logger) (*Transport, error) {
-	rpc, err := NewHandler(endpoints, log)
+func NewTransport(endpoints []string, requestTimeoutSec int,
+	vhost string, transport http.RoundTripper, log log.Logger) (*Transport, error) {
+
+	rpc, err := NewHandler(endpoints, requestTimeoutSec, log)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rpcsplitter/transport_test.go
+++ b/internal/rpcsplitter/transport_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestTransport(t *testing.T) {
 	rpcMock := &mockClient{t: t}
-	rpcHandler, _ := newHandlerWithClients([]rpcClient{{rpcCaller: rpcMock}}, null.New())
+	rpcHandler, _ := newHandlerWithClients([]rpcClient{{rpcCaller: rpcMock}}, 10, null.New())
 	roundTripper, _ := newTransport(rpcHandler, "rpcsplitter-vhost", nil)
 	httpClient := http.Client{Transport: roundTripper}
 	msg := jsonMarshal(t, rpcReq{


### PR DESCRIPTION
Ticket: https://app.shortcut.com/chronicle-labs/story/641/rpc-splitter-timeout-improvements

Allow the timeout for all endpoints in `rpc-splitter` to be configurable by the user, both at CLI and module level. E.g.

```
> export TIMEOUT_ENDPOINT=http://10.255.255.1
> rpc-splitter run --eth-rpc "https://infura...,https://alchemy,$TIMEOUT_ENDPOINT" -v debug --timeout 9
...
INFO[0116] Time taken for all endpoints                  duration=9.002462541s tag=RPCSPLITTER
```

Preps for [sc627](https://app.shortcut.com/chronicle-labs/story/627/gofer-timeout-improvements).

- [x] ensure that by default timeout are shorther the deeper we are in the stack. i.e. gofer_timeout>rpcsplitter_timeout **(NOTE for this PR, we're just defaulting [under 10s](https://github.com/chronicleprotocol/oracle-suite/pull/37/files#diff-ce67db20ebd056536fdf966cda3237294f5412fa14d51551ad419c9c77f460e8R35) which should be lower than Gofer. Work done in `sc627` should build on this PR to make this configurable in relation to Gofer**
- [x] make timeout and retry values configurable by the end user
- [x] ensure the timeout/retry values are passable at the module level so the config.json can be used to specify the timeout relation, i.e. between Gofer/splitter


