### PR TITLE
Gofer timeout improvements [sc-627]

### DIFF
--- a/internal/config/gofer/gofer.go
+++ b/internal/config/gofer/gofer.go
@@ -154,9 +154,9 @@ func (c *Gofer) configureRPCClient() (*rpc.Gofer, error) {
 }
 
 func (c *Gofer) buildOrigins(cli pkgEthereum.Client) (*origins.Set, error) {
-	const defaultWorkerCount = 5
+	const defaultWorkerCount = 10
 	wp := query.NewHTTPWorkerPool(defaultWorkerCount)
-	originSet := origins.DefaultOriginSet(wp, defaultWorkerCount)
+	originSet := origins.DefaultOriginSet(wp)
 	for name, origin := range c.Origins {
 		handler, err := NewHandler(origin.Type, wp, cli, origin.URL, origin.Params)
 		if err != nil || handler == nil {

--- a/internal/config/gofer/gofer.go
+++ b/internal/config/gofer/gofer.go
@@ -35,7 +35,7 @@ import (
 )
 
 const defaultTTL = 60 * time.Second
-const maxTTL = 300 * time.Second
+const maxTTL = 240 * time.Second
 
 type ErrCyclicReference struct {
 	Pair gofer.Pair

--- a/internal/config/gofer/gofer.go
+++ b/internal/config/gofer/gofer.go
@@ -35,7 +35,7 @@ import (
 )
 
 const defaultTTL = 60 * time.Second
-const maxTTL = 60 * time.Second
+const maxTTL = 300 * time.Second
 
 type ErrCyclicReference struct {
 	Pair gofer.Pair

--- a/internal/config/gofer/gofer_test.go
+++ b/internal/config/gofer/gofer_test.go
@@ -236,7 +236,7 @@ func TestConfig_buildGraphs_DefaultTTL(t *testing.T) {
 	p, _ := gofer.NewPair("A/B")
 	g, _ := config.buildGraphs()
 
-	assert.Equal(t, 120*time.Second, g[p].Children()[0].(*nodes.OriginNode).MaxTTL())
+	assert.Equal(t, 360*time.Second, g[p].Children()[0].(*nodes.OriginNode).MaxTTL())
 	assert.Equal(t, 60*time.Second, g[p].Children()[0].(*nodes.OriginNode).MinTTL())
 }
 
@@ -259,7 +259,7 @@ func TestConfig_buildGraphs_OriginTTL(t *testing.T) {
 	p, _ := gofer.NewPair("A/B")
 	g, _ := config.buildGraphs()
 
-	assert.Equal(t, 180*time.Second, g[p].Children()[0].(*nodes.OriginNode).MaxTTL())
+	assert.Equal(t, 420*time.Second, g[p].Children()[0].(*nodes.OriginNode).MaxTTL())
 	assert.Equal(t, 120*time.Second, g[p].Children()[0].(*nodes.OriginNode).MinTTL())
 }
 
@@ -282,7 +282,7 @@ func TestConfig_buildGraphs_MedianTTL(t *testing.T) {
 	p, _ := gofer.NewPair("A/B")
 	g, _ := config.buildGraphs()
 
-	assert.Equal(t, 180*time.Second, g[p].Children()[0].(*nodes.OriginNode).MaxTTL())
+	assert.Equal(t, 420*time.Second, g[p].Children()[0].(*nodes.OriginNode).MaxTTL())
 	assert.Equal(t, 120*time.Second, g[p].Children()[0].(*nodes.OriginNode).MinTTL())
 }
 

--- a/internal/config/gofer/gofer_test.go
+++ b/internal/config/gofer/gofer_test.go
@@ -236,7 +236,7 @@ func TestConfig_buildGraphs_DefaultTTL(t *testing.T) {
 	p, _ := gofer.NewPair("A/B")
 	g, _ := config.buildGraphs()
 
-	assert.Equal(t, 360*time.Second, g[p].Children()[0].(*nodes.OriginNode).MaxTTL())
+	assert.Equal(t, 300*time.Second, g[p].Children()[0].(*nodes.OriginNode).MaxTTL())
 	assert.Equal(t, 60*time.Second, g[p].Children()[0].(*nodes.OriginNode).MinTTL())
 }
 
@@ -259,7 +259,7 @@ func TestConfig_buildGraphs_OriginTTL(t *testing.T) {
 	p, _ := gofer.NewPair("A/B")
 	g, _ := config.buildGraphs()
 
-	assert.Equal(t, 420*time.Second, g[p].Children()[0].(*nodes.OriginNode).MaxTTL())
+	assert.Equal(t, 360*time.Second, g[p].Children()[0].(*nodes.OriginNode).MaxTTL())
 	assert.Equal(t, 120*time.Second, g[p].Children()[0].(*nodes.OriginNode).MinTTL())
 }
 
@@ -282,7 +282,7 @@ func TestConfig_buildGraphs_MedianTTL(t *testing.T) {
 	p, _ := gofer.NewPair("A/B")
 	g, _ := config.buildGraphs()
 
-	assert.Equal(t, 420*time.Second, g[p].Children()[0].(*nodes.OriginNode).MaxTTL())
+	assert.Equal(t, 360*time.Second, g[p].Children()[0].(*nodes.OriginNode).MaxTTL())
 	assert.Equal(t, 120*time.Second, g[p].Children()[0].(*nodes.OriginNode).MinTTL())
 }
 

--- a/internal/query/http_worker_pool.go
+++ b/internal/query/http_worker_pool.go
@@ -15,9 +15,6 @@
 
 package query
 
-// max amount of tasks in worker pool queue
-const maxTasksQueue = 10
-
 // WorkerPool interface for any Query Engine worker pools
 type WorkerPool interface {
 	Query(req *HTTPRequest) *HTTPResponse
@@ -39,7 +36,7 @@ type asyncHTTPRequest struct {
 func NewHTTPWorkerPool(workerCount int) *HTTPWorkerPool {
 	wp := &HTTPWorkerPool{
 		workerCount: workerCount,
-		input:       make(chan *asyncHTTPRequest, maxTasksQueue),
+		input:       make(chan *asyncHTTPRequest, workerCount),
 	}
 
 	for w := 0; w < wp.workerCount; w++ {

--- a/pkg/gofer/graph/async_gofer_test.go
+++ b/pkg/gofer/graph/async_gofer_test.go
@@ -1,0 +1,26 @@
+package graph
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/chronicleprotocol/oracle-suite/pkg/gofer"
+	"github.com/chronicleprotocol/oracle-suite/pkg/gofer/graph/nodes"
+)
+
+func Test_gcdTTL(t *testing.T) {
+	p := gofer.Pair{Base: "A", Quote: "B"}
+	root := nodes.NewMedianAggregatorNode(p, 1)
+	ttl := time.Second * time.Duration(time.Now().Unix()+10)
+	on1 := nodes.NewOriginNode(nodes.OriginPair{Origin: "a", Pair: p}, 12*time.Second, ttl)
+	on2 := nodes.NewOriginNode(nodes.OriginPair{Origin: "b", Pair: p}, 6*time.Second, ttl)
+	on3 := nodes.NewOriginNode(nodes.OriginPair{Origin: "b", Pair: p}, 10*time.Second, ttl)
+
+	root.AddChild(on1)
+	root.AddChild(on2)
+	root.AddChild(on3)
+
+	assert.Equal(t, 2*time.Second, gcdTTL([]nodes.Node{root}))
+}

--- a/pkg/gofer/graph/feeder/feeder.go
+++ b/pkg/gofer/graph/feeder/feeder.go
@@ -43,6 +43,7 @@ func (w Warnings) ToError() error {
 }
 
 type Feedable interface {
+	nodes.Node
 	// OriginPair returns the origin and pair which are acceptable for
 	// this Node.
 	OriginPair() nodes.OriginPair
@@ -206,25 +207,4 @@ func mapOriginResult(origin string, fr origins.FetchResult) nodes.OriginPrice {
 		Origin: origin,
 		Error:  fr.Error,
 	}
-}
-
-// getGCDTTL returns the greatest common divisor of nodes minTTLs.
-func getGCDTTL(ns []nodes.Node) time.Duration {
-	ttl := time.Duration(0)
-	nodes.Walk(func(n nodes.Node) {
-		if f, ok := n.(Feedable); ok {
-			if ttl == 0 {
-				ttl = f.MinTTL()
-			}
-			a := ttl
-			b := f.MinTTL()
-			for b != 0 {
-				t := b
-				b = a % b
-				a = t
-			}
-			ttl = a
-		}
-	}, ns...)
-	return ttl
 }

--- a/pkg/gofer/graph/feeder/feeder_test.go
+++ b/pkg/gofer/graph/feeder/feeder_test.go
@@ -352,18 +352,3 @@ func TestFeeder_Feed_BetweenTTLs(t *testing.T) {
 	assert.Equal(t, 12.0, o.Price().Ask)
 	assert.Equal(t, 11.0, o.Price().Volume24h)
 }
-
-func Test_getGCDTTL(t *testing.T) {
-	p := gofer.Pair{Base: "A", Quote: "B"}
-	root := nodes.NewMedianAggregatorNode(p, 1)
-	ttl := time.Second * time.Duration(time.Now().Unix()+10)
-	on1 := nodes.NewOriginNode(nodes.OriginPair{Origin: "a", Pair: p}, 12*time.Second, ttl)
-	on2 := nodes.NewOriginNode(nodes.OriginPair{Origin: "b", Pair: p}, 6*time.Second, ttl)
-	on3 := nodes.NewOriginNode(nodes.OriginPair{Origin: "b", Pair: p}, 10*time.Second, ttl)
-
-	root.AddChild(on1)
-	root.AddChild(on2)
-	root.AddChild(on3)
-
-	assert.Equal(t, 2*time.Second, getGCDTTL([]nodes.Node{root}))
-}

--- a/pkg/gofer/graph/feeder/feeder_test.go
+++ b/pkg/gofer/graph/feeder/feeder_test.go
@@ -67,7 +67,7 @@ func originsSetMock(prices map[string][]origins.Price) *origins.Set {
 		}
 		handlers[origin] = &mockHandler{mockedPrices: pricesMap}
 	}
-	return origins.NewSet(handlers, 10)
+	return origins.NewSet(handlers)
 }
 
 func TestFeeder_Feed_EmptyGraph(t *testing.T) {

--- a/pkg/gofer/graph/gofer_test.go
+++ b/pkg/gofer/graph/gofer_test.go
@@ -249,7 +249,7 @@ func init() {
 		"b": &testExchange{},
 		"x": &testExchange{},
 		"y": &testExchange{},
-	}, 10), null.New())
+	}), null.New())
 }
 
 func TestGofer_Models_SinglePair(t *testing.T) {

--- a/pkg/gofer/origins/errors.go
+++ b/pkg/gofer/origins/errors.go
@@ -23,6 +23,5 @@ import (
 var ErrEmptyOriginResponse = fmt.Errorf("empty origin response received")
 var ErrMissingResponseForPair = fmt.Errorf("no response for pair from origin")
 var ErrInvalidResponseStatus = fmt.Errorf("invalid response status from origin")
-var ErrInvalidResponse = fmt.Errorf("invalid response from origin")
 var ErrInvalidPrice = fmt.Errorf("invalid price from origin")
 var ErrUnknownOrigin = errors.New("unknown origin")

--- a/pkg/gofer/origins/origin_test.go
+++ b/pkg/gofer/origins/origin_test.go
@@ -42,7 +42,7 @@ func (suite *OriginsSuite) SetupSuite() {
 	suite.pool = pool
 	suite.set = NewSet(map[string]Handler{
 		"binance": NewBaseExchangeHandler(Binance{WorkerPool: pool}, nil),
-	}, 10)
+	})
 }
 
 func (suite *OriginsSuite) TestCallWithMissingOrigin() {


### PR DESCRIPTION
This PR changes the way Gofer fetches prices. Instead of spawning one goroutine, it spawns a separate goroutine for each origin. This way, one broken origin should not delay fetching prices from others.

Additionally:
- Increases price expiation time from 2mins to 5mins
- Increases simultaneous HTTP requests from 5 to 10