### PR TITLE
sc812, adds rETH circuit breaker logic post price

### DIFF
--- a/cmd/gofer/README.md
+++ b/cmd/gofer/README.md
@@ -129,6 +129,8 @@ Price model for each asset pair consists of three keys: `method`, `sources` and 
       the `params` field:
         - `minimumSuccessfulSources` - minimum number of successfully retrieved sources to consider calculated median
           price as reliable.
+        - `postPriceHook` - In some cases a check should be done after the median price has been obtained. E.g. in the case of `rETH`, a circuit breaker value is checked against the obtained median, and if the deviation is high enough, a price error will be set.
+
 
 ### Origins configuration
 

--- a/cmd/gofer/cmd_pairs.go
+++ b/cmd/gofer/cmd_pairs.go
@@ -34,7 +34,7 @@ func NewPairsCmd(opts *options) *cobra.Command {
 		Long:    `List all supported asset pairs.`,
 		RunE: func(_ *cobra.Command, args []string) (err error) {
 			ctx, ctxCancel := signal.NotifyContext(context.Background(), os.Interrupt)
-			sup, gof, mar, err := PrepareClientServices(ctx, opts)
+			sup, gof, mar, _, err := PrepareClientServices(ctx, opts)
 			if err != nil {
 				return err
 			}

--- a/cmd/gofer/cmd_prices.go
+++ b/cmd/gofer/cmd_prices.go
@@ -34,7 +34,7 @@ func NewPricesCmd(opts *options) *cobra.Command {
 		Long:    `Return prices for given PAIRs.`,
 		RunE: func(c *cobra.Command, args []string) (err error) {
 			ctx, ctxCancel := signal.NotifyContext(context.Background(), os.Interrupt)
-			sup, gof, mar, err := PrepareClientServices(ctx, opts)
+			sup, gof, mar, hook, err := PrepareClientServices(ctx, opts)
 			if err != nil {
 				return err
 			}
@@ -61,6 +61,10 @@ func NewPricesCmd(opts *options) *cobra.Command {
 				return err
 			}
 			prices, err := gof.Prices(pairs...)
+			if err != nil {
+				return err
+			}
+			err = hook.Check(prices)
 			if err != nil {
 				return err
 			}

--- a/config.json
+++ b/config.json
@@ -365,7 +365,10 @@
           [{ "origin": "curve", "pair": "RETH/WSTETH" },{ "origin": ".", "pair": "WSTETH/ETH" }]
         ],
         "params": {
-          "minimumSuccessfulSources": 3
+          "minimumSuccessfulSources": 3,
+          "postPriceHook": {
+              "circuitContract": "0xa3105dee5ec73a7003482b1a8968dc88666f3589"
+          }
         }
       },
       "RETH/USD": {

--- a/e2e/gofer/Dockerfile
+++ b/e2e/gofer/Dockerfile
@@ -5,11 +5,13 @@ COPY . .
 ENV CGO_ENABLED=0 \
     GOSUMDB=off
 
-RUN rm -rf dist \
-    && mkdir dist \
-    && go mod vendor \
-    && go build -o dist/gofer ./cmd/gofer \
-    && go build -o dist/rpc-splitter ./cmd/rpc-splitter
+# NOTE splitting each command into its own RUN statement allows better insight
+# when a specific command fails
+RUN rm -rf dist
+RUN mkdir dist
+RUN go mod vendor
+RUN go build -o dist/gofer ./cmd/gofer
+RUN go build -o dist/rpc-splitter ./cmd/rpc-splitter
 
 FROM golang:1-alpine
 RUN apk --no-cache add ca-certificates git bash

--- a/e2e/gofer/go.mod
+++ b/e2e/gofer/go.mod
@@ -3,7 +3,7 @@ module gofere2e
 go 1.18
 
 require (
-	github.com/chronicleprotocol/infestor v0.2.7
+	github.com/chronicleprotocol/infestor v0.2.10
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/e2e/gofer/go.sum
+++ b/e2e/gofer/go.sum
@@ -1,5 +1,5 @@
-github.com/chronicleprotocol/infestor v0.2.7 h1:jOCkjRwPeCKvCpsWihKGpkhivvN42MG83G37iKlu3Qc=
-github.com/chronicleprotocol/infestor v0.2.7/go.mod h1:CGYBL65xIWTuh97/8zPM1lvnt+eFI41SAqDj5MW7ZVw=
+github.com/chronicleprotocol/infestor v0.2.10 h1:BwlfbaFsOs8x7+Wxd4nRaFRdxyee5zaFxyYPvvlW5bw=
+github.com/chronicleprotocol/infestor v0.2.10/go.mod h1:CGYBL65xIWTuh97/8zPM1lvnt+eFI41SAqDj5MW7ZVw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/e2e/gofer/gofer_config.json
+++ b/e2e/gofer/gofer_config.json
@@ -195,7 +195,10 @@
           [{ "origin": "curve", "pair": "RETH/WSTETH" },{ "origin": ".", "pair": "WSTETH/ETH" }]
         ],
         "params": {
-          "minimumSuccessfulSources": 3
+          "minimumSuccessfulSources": 3,
+          "postPriceHook": {
+              "circuitContract": "0xa3105dee5ec73a7003482b1a8968dc88666f3589"
+          }
         }
       },
       "RETH/USD": {

--- a/e2e/gofer/price_reth_test.go
+++ b/e2e/gofer/price_reth_test.go
@@ -20,33 +20,20 @@ type PriceRETHE2ESuite struct {
 func (s *PriceRETHE2ESuite) TestPrice() {
 	err := infestor.NewMocksBuilder().
 		Reset().
-		// "RETH/ETH": {
-		// [{ "origin": "rocketpool", "pair": "RETH/ETH" }],
-		// [{ "origin": "balancerV2", "pair": "RETH/ETH" }],
-		// [{ "origin": "curve", "pair": "RETH/WSTETH" },{ "origin": ".", "pair": "WSTETH/ETH" }]
-		// "minimumSuccessfulSources": 3
 		Add(origin.NewExchange("rocketpool").WithSymbol("RETH/ETH")).
-		Add(origin.NewExchange("balancerV2").WithSymbol("RETH/WETH")).
+		Add(origin.NewExchange("balancerV2").WithSymbol("RETH/WETH").
+			WithCustom("rate", "0x0000000000000000000000000000000000000000000000000EF976AF325D68E80000000000000000000000000000000000000000000000000000000000002A300000000000000000000000000000000000000000000000000000000062D81469").
+			WithCustom("price", "0x0000000000000000000000000000000000000000000000000d925d70884a3395")).
 		Add(origin.NewExchange("curve").WithSymbol("RETH/WSTETH")).
-
-		// "WSTETH/ETH": {
-		// [{ "origin": "wsteth", "pair": "WSTETH/STETH" },{ "origin": ".", "pair": "STETH/ETH" }]
-		// "minimumSuccessfulSources": 1
 		Add(origin.NewExchange("wsteth").WithSymbol("WSTETH/STETH")).
-
-		// "STETH/ETH": {
-		// [{ "origin": "curve", "pair": "STETH/ETH" }],
-		// [{ "origin": "balancerV2", "pair": "STETH/ETH" }]
-		// "minimumSuccessfulSources": 2
-		Add(origin.NewExchange("curve").WithSymbol("STETH/ETH")).
-		Add(origin.NewExchange("balancerV2").WithSymbol("STETH/ETH")).
-
-		// getBlockNumber
+		Add(origin.NewExchange("curve").WithSymbol("STETH/ETH").WithPrice(1.044)).
+		Add(origin.NewExchange("balancerV2").WithSymbol("STETH/ETH").
+			WithCustom("rate", "0x0000000000000000000000000000000000000000000000000EF976AF325D68E80000000000000000000000000000000000000000000000000000000000002A300000000000000000000000000000000000000000000000000000000062D81469").
+			WithCustom("price", "0x0000000000000000000000000000000000000000000000000d925d70884a3395")).
 		Add(origin.NewExchange("ethrpc")).
 		Deploy(s.api)
 
 	s.Require().NoError(err)
-
 	out, _, err := callGofer("-c", s.ConfigPath, "price", "RETH/ETH")
 	s.Require().NoError(err)
 	s.Require().NotEmpty(out)
@@ -54,8 +41,30 @@ func (s *PriceRETHE2ESuite) TestPrice() {
 	p, err := parseGoferPrice(out)
 	s.Require().NoError(err)
 	s.Require().Equal("aggregator", p.Type)
-	s.Require().Equal(1.0, p.Price)
+	s.Require().Equal(1.0511045977366833, p.Price)
 	s.Require().Greater(len(p.Prices), 0)
 	s.Require().Equal("median", p.Parameters["method"])
 	s.Require().Equal("3", p.Parameters["minimumSuccessfulSources"])
+}
+
+func (s *PriceRETHE2ESuite) TestCircuit() {
+	err := infestor.NewMocksBuilder().
+		Reset().
+		Add(origin.NewExchange("rocketpool").WithSymbol("RETH/ETH").
+			WithCustom("price", "0x0000000000000000000000000000000000000000000000001b7314242fae3395")). // 1.97
+		Add(origin.NewExchange("balancerV2").WithSymbol("RETH/WETH").
+			WithCustom("rate", "0x0000000000000000000000000000000000000000000000000EF976AF325D68E80000000000000000000000000000000000000000000000000000000000002A300000000000000000000000000000000000000000000000000000000062D81469").
+			WithCustom("price", "0x0000000000000000000000000000000000000000000000000d925d70884a3395")).
+		Add(origin.NewExchange("curve").WithSymbol("RETH/WSTETH")).
+		Add(origin.NewExchange("wsteth").WithSymbol("WSTETH/STETH")).
+		Add(origin.NewExchange("curve").WithSymbol("STETH/ETH").WithPrice(1.044)).
+		Add(origin.NewExchange("balancerV2").WithSymbol("STETH/ETH").
+			WithCustom("rate", "0x0000000000000000000000000000000000000000000000000EF976AF325D68E80000000000000000000000000000000000000000000000000000000000002A300000000000000000000000000000000000000000000000000000000062D81469").
+			WithCustom("price", "0x0000000000000000000000000000000000000000000000000d925d70884a3395")).
+		Add(origin.NewExchange("ethrpc")).
+		Deploy(s.api)
+
+	s.Require().NoError(err)
+	_, _, err = callGofer("-c", s.ConfigPath, "price", "RETH/ETH")
+	s.Require().Error(err)
 }

--- a/e2e/gofer/price_wsteth_test.go
+++ b/e2e/gofer/price_wsteth_test.go
@@ -21,7 +21,9 @@ func (s *PriceWSTETHE2ESuite) TestPrice() {
 	err := infestor.NewMocksBuilder().
 		Reset().
 		Add(origin.NewExchange("wsteth").WithSymbol("WSTETH/ETH").WithPrice(1)).
-		Add(origin.NewExchange("balancerV2").WithSymbol("STETH/ETH").WithPrice(1)).
+		Add(origin.NewExchange("balancerV2").WithSymbol("STETH/ETH").
+			WithCustom("rate", "0x0000000000000000000000000000000000000000000000000EF976AF325D68E80000000000000000000000000000000000000000000000000000000000002A300000000000000000000000000000000000000000000000000000000062D81469").
+			WithCustom("price", "0x0000000000000000000000000000000000000000000000000d925d70884a3395")).
 		Add(origin.NewExchange("curve").WithSymbol("STETH/ETH").WithPrice(1)).
 		Add(origin.NewExchange("ethrpc")).
 		Deploy(s.api)
@@ -35,7 +37,7 @@ func (s *PriceWSTETHE2ESuite) TestPrice() {
 	p, err := parseGoferPrice(out)
 	s.Require().NoError(err)
 	s.Require().Equal("aggregator", p.Type)
-	s.Require().Equal(1.065747073876745, p.Price)
+	s.Require().Equal(1.0561332642043832, p.Price)
 	s.Require().Greater(len(p.Prices), 0)
 	s.Require().Equal("median", p.Parameters["method"])
 	s.Require().Equal("1", p.Parameters["minimumSuccessfulSources"])

--- a/pkg/config/gofer/origin.go
+++ b/pkg/config/gofer/origin.go
@@ -209,7 +209,7 @@ func NewHandler(
 		if err != nil {
 			return nil, err
 		}
-		h, err := origins.NewRockerPool(cli, contracts, averageFromBlocks)
+		h, err := origins.NewRocketPool(cli, contracts, averageFromBlocks)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/price/provider/graph/nodes/nodes.go
+++ b/pkg/price/provider/graph/nodes/nodes.go
@@ -15,7 +15,9 @@
 
 package nodes
 
-import "github.com/chronicleprotocol/oracle-suite/pkg/price/provider"
+import (
+	"github.com/chronicleprotocol/oracle-suite/pkg/price/provider"
+)
 
 // Node represents generics node in a graph.
 type Node interface {

--- a/pkg/price/provider/hooks.go
+++ b/pkg/price/provider/hooks.go
@@ -1,0 +1,90 @@
+//  Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chronicleprotocol/oracle-suite/pkg/ethereum"
+	"github.com/chronicleprotocol/oracle-suite/pkg/price/provider/hooks"
+)
+
+type PostPriceHook struct {
+	cli      ethereum.Client
+	ctx      context.Context
+	handlers map[string]interface{}
+}
+
+const RocketPoolPair = "RETH/ETH"
+
+type HookParams map[string]map[string]interface{}
+
+func NewHookParams() HookParams {
+	return make(HookParams)
+}
+
+func NewPostPriceHook(ctx context.Context, cli ethereum.Client, params HookParams) (*PostPriceHook, error) {
+	handlers := make(map[string]interface{})
+	for k, v := range params {
+		switch k {
+		case RocketPoolPair:
+			h, err := hooks.NewRocketPoolCircuitBreaker(v)
+			if err != nil {
+				return nil, err
+			}
+			handlers[k] = h
+		default:
+		}
+	}
+
+	return &PostPriceHook{
+		cli:      cli,
+		ctx:      ctx,
+		handlers: handlers,
+	}, nil
+}
+
+func (o *PostPriceHook) Check(prices map[Pair]*Price) error {
+	for pair, price := range prices {
+		switch pair.String() {
+		case RocketPoolPair:
+			if _, ok := o.handlers[RocketPoolPair]; !ok {
+				return fmt.Errorf("no post price hook handler found for %s", RocketPoolPair)
+			}
+
+			var refPrice float64
+			for _, origin := range price.Prices {
+				if origin.Parameters["origin"] == "rocketpool" {
+					refPrice = origin.Price
+					break
+				}
+			}
+			if refPrice == 0 {
+				prices[pair].Error = fmt.Sprintf("post price hook failed for %s, reference price should be > 0", pair.String())
+				return nil
+			}
+
+			err := o.handlers[RocketPoolPair].(*hooks.RocketPoolCircuitBreaker).Check(o.ctx, o.cli, price.Price, refPrice)
+			if err != nil {
+				prices[pair].Error = err.Error()
+			}
+			return nil
+		default:
+		}
+	}
+	return nil
+}

--- a/pkg/price/provider/hooks/circuit_abi.json
+++ b/pkg/price/provider/hooks/circuit_abi.json
@@ -1,0 +1,28 @@
+[
+  {
+    "inputs": [],
+    "name": "read",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "divisor",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/pkg/price/provider/hooks/rocketpool.go
+++ b/pkg/price/provider/hooks/rocketpool.go
@@ -1,0 +1,97 @@
+//  Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package hooks
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"math"
+	"math/big"
+	"strings"
+
+	"github.com/chronicleprotocol/oracle-suite/pkg/ethereum"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+//go:embed circuit_abi.json
+var circuitABI string
+
+const circuitContractKey = "circuitContract"
+
+type RocketPoolCircuitBreaker struct {
+	contract   common.Address
+	circuitABI abi.ABI
+}
+
+func NewRocketPoolCircuitBreaker(params map[string]interface{}) (*RocketPoolCircuitBreaker, error) {
+	var ret RocketPoolCircuitBreaker
+	if _, ok := params[circuitContractKey]; !ok {
+		return nil, fmt.Errorf("post price hook failed, could not find %s parameter for RETH", circuitContractKey)
+	}
+
+	c, ok := params[circuitContractKey].(string)
+	if !ok {
+		return nil, fmt.Errorf("post price hook failed for RETH incorrect params: %s", c)
+	}
+	ret.contract = ethereum.HexToAddress(c)
+
+	cabi, err := abi.JSON(strings.NewReader(circuitABI))
+	if err != nil {
+		return nil, err
+	}
+	ret.circuitABI = cabi
+
+	return &ret, nil
+}
+
+func (o *RocketPoolCircuitBreaker) Check(ctx context.Context,
+	cli ethereum.Client, medianPrice, refPrice float64) error {
+
+	// read()
+	callData, err := o.circuitABI.Pack("read")
+	if err != nil {
+		return fmt.Errorf("failed to get contract args for %s: %w", circuitContractKey, err)
+	}
+	response, err := cli.Call(ctx, ethereum.Call{Address: o.contract, Data: callData})
+	if err != nil {
+		return err
+	}
+	val := new(big.Float).SetInt(new(big.Int).SetBytes(response))
+	// divisor()
+	callData, err = o.circuitABI.Pack("divisor")
+	if err != nil {
+		return fmt.Errorf("failed to get contract args for %s: %w", circuitContractKey, err)
+	}
+	response, err = cli.Call(ctx, ethereum.Call{Address: o.contract, Data: callData})
+	if err != nil {
+		return err
+	}
+	div := new(big.Float).SetInt(new(big.Int).SetBytes(response))
+
+	v, _ := val.Float64()
+	d, _ := div.Float64()
+	breaker := v / d
+
+	deviation := math.Abs(1.0 - (refPrice / medianPrice))
+
+	if deviation > breaker {
+		return fmt.Errorf("error rETH circuit breaker tripped: %f > %f", deviation, breaker)
+	}
+	return nil
+}

--- a/pkg/price/provider/hooks_test.go
+++ b/pkg/price/provider/hooks_test.go
@@ -1,0 +1,90 @@
+//  Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chronicleprotocol/oracle-suite/pkg/ethereum"
+	ethereumMocks "github.com/chronicleprotocol/oracle-suite/pkg/ethereum/mocks"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostPriceHook(t *testing.T) {
+	prices := make(map[Pair]*Price)
+
+	pair, err := NewPair("RETH/ETH")
+	assert.NoError(t, err)
+
+	prices[pair] = &Price{
+		Price: 1.0,
+		Prices: []*Price{
+			{
+				Parameters: map[string]string{
+					"origin": "rocketpool",
+				},
+				Price: 0.99,
+			},
+		},
+	}
+
+	contract := "0xdeadbeef"
+	params := make(map[string]interface{})
+	params["circuitContract"] = contract
+	pairParams := NewHookParams()
+	pairParams["RETH/ETH"] = params
+
+	cli := &ethereumMocks.Client{}
+	readMethodID := []byte{87, 222, 38, 164}
+	divisorMethodID := []byte{31, 45, 197, 239}
+
+	ctx := context.Background()
+	cli.On("Call", ctx, ethereum.Call{Address: ethereum.HexToAddress(contract), Data: readMethodID}).Return(
+		[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 39, 16},
+		nil,
+	)
+	cli.On("Call", ctx, ethereum.Call{Address: ethereum.HexToAddress(contract), Data: divisorMethodID}).Return(
+		[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 134, 160},
+		nil,
+	)
+
+	hook, err := NewPostPriceHook(context.Background(), cli, pairParams)
+	assert.NoError(t, err)
+
+	// Moderate price deviation, expect success
+	err = hook.Check(prices)
+	assert.NoError(t, err)
+	assert.True(t, prices[pair].Error == "")
+
+	// Extreme price deviation, expect error
+	prices[pair].Prices[0].Price = 2.0
+	err = hook.Check(prices)
+	assert.NoError(t, err)
+	assert.True(t, prices[pair].Error != "")
+	t.Log(prices[pair].Error)
+
+	// Price pair with no hooks defined succeeds
+	prices = make(map[Pair]*Price)
+	pair, err = NewPair("WAKA/WAKA")
+	assert.NoError(t, err)
+
+	prices[pair] = &Price{Price: 1.0}
+	err = hook.Check(prices)
+	assert.NoError(t, err)
+	assert.True(t, prices[pair].Error == "")
+}

--- a/pkg/price/provider/origins/balancerv2.go
+++ b/pkg/price/provider/origins/balancerv2.go
@@ -79,7 +79,7 @@ func (s BalancerV2) callOne(pair Pair) (*Price, error) {
 		return nil, err
 	}
 	if indirect {
-		return nil, fmt.Errorf("cannot use inverted pair to retrieve price: %s", pair.String())
+		return nil, fmt.Errorf("cannot use indirect pair to retrieve price: %s", pair.String())
 	}
 	var priceFloat *big.Float
 	{
@@ -108,6 +108,7 @@ func (s BalancerV2) callOne(pair Pair) (*Price, error) {
 		if err != nil {
 			return nil, err
 		}
+
 		priceFloat = new(big.Float).Mul(reduceEtherAverageFloat(resp), priceFloat)
 	}
 

--- a/pkg/price/provider/origins/origin.go
+++ b/pkg/price/provider/origins/origin.go
@@ -328,7 +328,10 @@ func buildOriginURL(template, configURL, defaultURL string, a ...interface{}) st
 func reduceEtherAverageFloat(r [][]byte) *big.Float {
 	total := new(big.Float).SetInt64(0)
 	for _, resp := range r {
-		price := new(big.Int).SetBytes(resp)
+		// TODO(jamesr) Always uint256, so even if resp is larger, truncate.
+		// However, this assumes that we only care about the first 32 bytes.
+		// You might want the last 32... perhaps revisit this.
+		price := new(big.Int).SetBytes(resp[0:32])
 		total = new(big.Float).Add(
 			total,
 			new(big.Float).Quo(new(big.Float).SetInt(price), new(big.Float).SetUint64(ether)),

--- a/pkg/price/provider/origins/rocketpool.go
+++ b/pkg/price/provider/origins/rocketpool.go
@@ -28,22 +28,23 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/ethereum"
 )
 
-type RockerPool struct {
-	ethClient ethereum.Client
-	addrs     ContractAddresses
-	abi       abi.ABI
-	blocks    []int64
+type RocketPool struct {
+	ethClient  ethereum.Client
+	addrs      ContractAddresses
+	abi        abi.ABI
+	circuitABI abi.ABI
+	blocks     []int64
 }
 
 //go:embed rocketpool_abi.json
 var rocketPoolABI string
 
-func NewRockerPool(cli ethereum.Client, addrs ContractAddresses, blocks []int64) (*RockerPool, error) {
+func NewRocketPool(cli ethereum.Client, addrs ContractAddresses, blocks []int64) (*RocketPool, error) {
 	a, err := abi.JSON(strings.NewReader(rocketPoolABI))
 	if err != nil {
 		return nil, err
 	}
-	return &RockerPool{
+	return &RocketPool{
 		ethClient: cli,
 		addrs:     addrs,
 		abi:       a,
@@ -51,11 +52,11 @@ func NewRockerPool(cli ethereum.Client, addrs ContractAddresses, blocks []int64)
 	}, nil
 }
 
-func (s RockerPool) PullPrices(pairs []Pair) []FetchResult {
+func (s RocketPool) PullPrices(pairs []Pair) []FetchResult {
 	return callSinglePairOrigin(&s, pairs)
 }
 
-func (s RockerPool) callOne(pair Pair) (*Price, error) {
+func (s RocketPool) callOne(pair Pair) (*Price, error) {
 	contract, inverted, err := s.addrs.AddressByPair(pair)
 	if err != nil {
 		return nil, err
@@ -76,6 +77,7 @@ func (s RockerPool) callOne(pair Pair) (*Price, error) {
 		return nil, err
 	}
 	price, _ := reduceEtherAverageFloat(resp).Float64()
+
 	return &Price{
 		Pair:      pair,
 		Price:     price,

--- a/pkg/price/provider/origins/rocketpool_test.go
+++ b/pkg/price/provider/origins/rocketpool_test.go
@@ -28,43 +28,44 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type RockerPoolSuite struct {
+type RocketPoolSuite struct {
 	suite.Suite
 	addresses ContractAddresses
 	client    *ethereumMocks.Client
 	origin    *BaseExchangeHandler
 }
 
-func (suite *RockerPoolSuite) SetupSuite() {
+func (suite *RocketPoolSuite) SetupSuite() {
 	suite.addresses = ContractAddresses{
 		"RETH/ETH": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+		"Circuit":  "0xa3105dee5ec73a7003482b1a8968dc88666f3589",
 	}
 }
-func (suite *RockerPoolSuite) TearDownSuite() {
+func (suite *RocketPoolSuite) TearDownSuite() {
 	suite.addresses = nil
 }
 
-func (suite *RockerPoolSuite) SetupTest() {
+func (suite *RocketPoolSuite) SetupTest() {
 	suite.client = &ethereumMocks.Client{}
-	o, err := NewRockerPool(suite.client, suite.addresses, []int64{0, 10, 20})
+	o, err := NewRocketPool(suite.client, suite.addresses, []int64{0, 10, 20})
 	suite.NoError(err)
 	suite.origin = NewBaseExchangeHandler(o, nil)
 }
 
-func (suite *RockerPoolSuite) TearDownTest() {
+func (suite *RocketPoolSuite) TearDownTest() {
 	suite.origin = nil
 	suite.client = nil
 }
 
-func (suite *RockerPoolSuite) Origin() Handler {
+func (suite *RocketPoolSuite) Origin() Handler {
 	return suite.origin
 }
 
-func TestRockerPoolSuite(t *testing.T) {
-	suite.Run(t, new(RockerPoolSuite))
+func TestRocketPoolSuite(t *testing.T) {
+	suite.Run(t, new(RocketPoolSuite))
 }
 
-func (suite *RockerPoolSuite) TestSuccessResponse() {
+func (suite *RocketPoolSuite) TestSuccessResponse() {
 	resp := [][]byte{
 		common.BigToHash(big.NewInt(0.94 * 1e18)).Bytes(),
 		common.BigToHash(big.NewInt(0.98 * 1e18)).Bytes(),
@@ -90,7 +91,7 @@ func (suite *RockerPoolSuite) TestSuccessResponse() {
 	suite.client.AssertNumberOfCalls(suite.T(), "CallBlocks", 1)
 }
 
-func (suite *RockerPoolSuite) TestSuccessResponse_Inverted() {
+func (suite *RocketPoolSuite) TestSuccessResponse_Inverted() {
 	resp := [][]byte{
 		common.BigToHash(big.NewInt(0.94 * 1e18)).Bytes(),
 		common.BigToHash(big.NewInt(0.98 * 1e18)).Bytes(),
@@ -116,7 +117,7 @@ func (suite *RockerPoolSuite) TestSuccessResponse_Inverted() {
 	suite.client.AssertNumberOfCalls(suite.T(), "CallBlocks", 1)
 }
 
-func (suite *RockerPoolSuite) TestFailOnWrongPair() {
+func (suite *RocketPoolSuite) TestFailOnWrongPair() {
 	pair := Pair{Base: "x", Quote: "y"}
 	cr := suite.origin.Fetch([]Pair{pair})
 	suite.Require().EqualError(cr[0].Error, "failed to get contract address for pair: x/y")

--- a/pkg/price/provider/provider.go
+++ b/pkg/price/provider/provider.go
@@ -108,3 +108,7 @@ type Price struct {
 	Prices     []*Price
 	Error      string
 }
+
+type PriceHook interface {
+	Check(map[Pair]*Price) error
+}


### PR DESCRIPTION
- [x] adds a "post price hook" mechanism to price provider that can check obtained price against some criteria, e.g. rETH reference price/circuit breaker
- [x] `RockerPool` -> `RocketPool` typo
- [x]  fixes rETH tests for balancerv2
- [x]  check RocketPool circuit breaker against DSValue from chain
- [x] fixes bug in return from balancerv2 `getPriceRateCache`