### PR TITLE
Enable interpolation config for different var identifiers

### DIFF
--- a/cmd/gofer/README.md
+++ b/cmd/gofer/README.md
@@ -181,11 +181,10 @@ Example:
         - `[]metrics` - List of metric definitions
             - `matchMessage` (`string`) - Regular expression that must match a log message.
             - `matchFields` (`[string]string`) - Map of fields whose values must match a regular expression.
-            - `name` (`string`) - Name of metric. It can contain references to log fields in the format `$${path}`,
-              where
-              path is the dot-separated path to the field.
+            - `name` (`string`) - Name of metric. It can contain references to log fields in the format `%{path}`,
+              where path is the dot-separated path to the field.
             - `tags` (`[string][]string`) - List of metric tags. They can contain references to log fields in the
-              format `${path}`, where path is the dot-separated path to the field.
+              format `%{path}`, where path is the dot-separated path to the field.
             - `value` (`string`) - Dot-separated path of the field with the metric value. If empty, the value 1 will be
               used as the metric value.
             - `scaleFactor` (`float`) - Scales the value by the specified number. If it is zero, scaling is not
@@ -207,9 +206,9 @@ Example:
 ### Environment variables
 
 It is possible to use environment variables anywhere in the configuration file. The syntax is similar as in the
-shell: `${ENV_VAR}`. If the environment  variable is not set, the error will be returned during the application
-startup. To escape the dollar sign, use `\$` or `$$`. The latter syntax is not supported inside variables. It is
-possible to define default values for environment variables. To do so, use the following syntax: `${ENV_VAR-default}`.
+shell: `${ENV_VAR}`. If the environment variable is not set, the error will be returned during the application
+startup. To escape the dollar sign, use `\$` It is possible to define default values for environment variables.
+To do so, use the following syntax: `${ENV_VAR-default}`.
 
 ## Commands
 

--- a/cmd/lair/README.md
+++ b/cmd/lair/README.md
@@ -130,10 +130,10 @@ Lair supports JSON and YAML configuration files.
         - `[]metrics` - List of metric definitions
             - `matchMessage` (`string`) - Regular expression that must match a log message.
             - `matchFields` (`[string]string`) - Map of fields whose values must match a regular expression.
-            - `name` (`string`) - Name of metric. It can contain references to log fields in the format `$${path}`,
+            - `name` (`string`) - Name of metric. It can contain references to log fields in the format `%{path}`,
               where path is the dot-separated path to the field.
             - `tags` (`[string][]string`) - List of metric tags. They can contain references to log fields in the
-              format `${path}`, where path is the dot-separated path to the field.
+              format `%{path}`, where path is the dot-separated path to the field.
             - `value` (`string`) - Dot-separated path of the field with the metric value. If empty, the value 1 will be
               used as the metric value.
             - `scaleFactor` (`float`) - Scales the value by the specified number. If it is zero, scaling is not
@@ -180,8 +180,8 @@ Lair supports JSON and YAML configuration files.
 
 It is possible to use environment variables anywhere in the configuration file. The syntax is similar as in the
 shell: `${ENV_VAR}`. If the environment variable is not set, the error will be returned during the application
-startup. To escape the dollar sign, use `\$` or `$$`. The latter syntax is not supported inside variables. It is
-possible to define default values for environment variables. To do so, use the following syntax: `${ENV_VAR-default}`.
+startup. To escape the dollar sign, use `\$` It is possible to define default values for environment variables.
+To do so, use the following syntax: `${ENV_VAR-default}`.
 
 ## API
 

--- a/cmd/leeloo/README.md
+++ b/cmd/leeloo/README.md
@@ -168,10 +168,10 @@ Leeloo supports JSON and YAML configuration files.
         - `[]metrics` - List of metric definitions
             - `matchMessage` (`string`) - Regular expression that must match a log message.
             - `matchFields` (`[string]string`) - Map of fields whose values must match a regular expression.
-            - `name` (`string`) - Name of metric. It can contain references to log fields in the format `$${path}`,
+            - `name` (`string`) - Name of metric. It can contain references to log fields in the format `%{path}`,
               where path is the dot-separated path to the field.
             - `tags` (`[string][]string`) - List of metric tags. They can contain references to log fields in the
-              format `${path}`, where path is the dot-separated path to the field.
+              format `%{path}`, where path is the dot-separated path to the field.
             - `value` (`string`) - Dot-separated path of the field with the metric value. If empty, the value 1 will be
               used as the metric value.
             - `scaleFactor` (`float`) - Scales the value by the specified number. If it is zero, scaling is not
@@ -220,8 +220,8 @@ Leeloo supports JSON and YAML configuration files.
 
 It is possible to use environment variables anywhere in the configuration file. The syntax is similar as in the
 shell: `${ENV_VAR}`. If the environment variable is not set, the error will be returned during the application
-startup. To escape the dollar sign, use `\$` or `$$`. The latter syntax is not supported inside variables. It is
-possible to define default values for environment variables. To do so, use the following syntax: `${ENV_VAR-default}`.
+startup. To escape the dollar sign, use `\$` It is possible to define default values for environment variables.
+To do so, use the following syntax: `${ENV_VAR-default}`.
 
 ## Supported events
 

--- a/cmd/spire-bootstrap/README.md
+++ b/cmd/spire-bootstrap/README.md
@@ -27,7 +27,7 @@ make
 ## Configuration
 
 To start working with Spire-Bootstrap, you have to create configuration file first. By default, the default config file
-location is `config.json` in the current working directory. You can change the config file location using the `--config` 
+location is `config.json` in the current working directory. You can change the config file location using the `--config`
 flag. Spire-Bootstrap supports JSON and YAML configuration files.
 
 ### Example configuration
@@ -82,11 +82,10 @@ flag. Spire-Bootstrap supports JSON and YAML configuration files.
         - `[]metrics` - List of metric definitions
             - `matchMessage` (`string`) - Regular expression that must match a log message.
             - `matchFields` (`[string]string`) - Map of fields whose values must match a regular expression.
-            - `name` (`string`) - Name of metric. It can contain references to log fields in the format `$${path}`,
-              where
-              path is the dot-separated path to the field.
+            - `name` (`string`) - Name of metric. It can contain references to log fields in the format `%{path}`,
+              where path is the dot-separated path to the field.
             - `tags` (`[string][]string`) - List of metric tags. They can contain references to log fields in the
-              format `${path}`, where path is the dot-separated path to the field.
+              format `%{path}`, where path is the dot-separated path to the field.
             - `value` (`string`) - Dot-separated path of the field with the metric value. If empty, the value 1 will be
               used as the metric value.
             - `scaleFactor` (`float`) - Scales the value by the specified number. If it is zero, scaling is not
@@ -103,9 +102,9 @@ flag. Spire-Bootstrap supports JSON and YAML configuration files.
 ### Environment variables
 
 It is possible to use environment variables anywhere in the configuration file. The syntax is similar as in the
-shell: `${ENV_VAR}`. If the environment  variable is not set, the error will be returned during the application
-startup. To escape the dollar sign, use `\$` or `$$`. The latter syntax is not supported inside variables. It is
-possible to define default values for environment variables. To do so, use the following syntax: `${ENV_VAR-default}`.
+shell: `${ENV_VAR}`. If the environment variable is not set, the error will be returned during the application
+startup. To escape the dollar sign, use `\$` It is possible to define default values for environment variables.
+To do so, use the following syntax: `${ENV_VAR-default}`.
 
 ## Commands
 

--- a/cmd/spire/README.md
+++ b/cmd/spire/README.md
@@ -156,10 +156,10 @@ Spire supports JSON and YAML configuration files.
         - `[]metrics` - List of metric definitions
             - `matchMessage` (`string`) - Regular expression that must match a log message.
             - `matchFields` (`[string]string`) - Map of fields whose values must match a regular expression.
-            - `name` (`string`) - Name of metric. It can contain references to log fields in the format `$${path}`, where
-              path is the dot-separated path to the field.
+            - `name` (`string`) - Name of metric. It can contain references to log fields in the format `%{path}`,
+              where path is the dot-separated path to the field.
             - `tags` (`[string][]string`) - List of metric tags. They can contain references to log fields in the
-              format `${path}`, where path is the dot-separated path to the field.
+              format `%{path}`, where path is the dot-separated path to the field.
             - `value` (`string`) - Dot-separated path of the field with the metric value. If empty, the value 1 will be
               used as the metric value.
             - `scaleFactor` (`float`) - Scales the value by the specified number. If it is zero, scaling is not
@@ -180,9 +180,9 @@ Spire supports JSON and YAML configuration files.
 ### Environment variables
 
 It is possible to use environment variables anywhere in the configuration file. The syntax is similar as in the
-shell: `${ENV_VAR}`. If the environment  variable is not set, the error will be returned during the application
-startup. To escape the dollar sign, use `\$` or `$$`. The latter syntax is not supported inside variables. It is
-possible to define default values for environment variables. To do so, use the following syntax: `${ENV_VAR-default}`.
+shell: `${ENV_VAR}`. If the environment variable is not set, the error will be returned during the application
+startup. To escape the dollar sign, use `\$` It is possible to define default values for environment variables.
+To do so, use the following syntax: `${ENV_VAR-default}`.
 
 ## Usage
 

--- a/pkg/log/grafana/log.go
+++ b/pkg/log/grafana/log.go
@@ -95,11 +95,11 @@ func New(level log.Level, cfg Config) (log.Logger, error) {
 	// Parse names and tags in advance to improve performance.
 	for n := range cfg.Metrics {
 		m := &cfg.Metrics[n]
-		m.parsedName = interpolate.Parse(m.Name)
+		m.parsedName = interpolate.ParsePercent(m.Name)
 		m.parsedTags = make(map[string][]interpolate.Parsed)
 		for k, v := range m.Tags {
 			for _, s := range v {
-				m.parsedTags[k] = append(m.parsedTags[k], interpolate.Parse(s))
+				m.parsedTags[k] = append(m.parsedTags[k], interpolate.ParsePercent(s))
 			}
 		}
 	}

--- a/pkg/log/grafana/log_test.go
+++ b/pkg/log/grafana/log_test.go
@@ -94,10 +94,10 @@ func TestLogger(t *testing.T) {
 		{
 			metrics: []Metric{{
 				MatchMessage: regexp.MustCompile("foo"),
-				Name:         "test.${key1}.${key2}.${key3.a}",
+				Name:         "test.%{key1}.%{key2}.%{key3.a}",
 				Tags: map[string][]string{
-					"tag1": {"${key1}"},
-					"tag2": {"${key2}", "${key3.a}"},
+					"tag1": {"%{key1}"},
+					"tag2": {"%{key2}", "%{key3.a}"},
 				},
 			}},
 			want: []want{
@@ -225,7 +225,7 @@ func TestLogger(t *testing.T) {
 		// Ignore metrics that uses invalid path in a name:
 		{
 			metrics: []Metric{
-				{MatchMessage: regexp.MustCompile("foo"), Name: "test.${invalid}"},
+				{MatchMessage: regexp.MustCompile("foo"), Name: "test.%{invalid}"},
 				{MatchMessage: regexp.MustCompile("foo"), Name: "test.valid"},
 			},
 			want: []want{
@@ -238,7 +238,7 @@ func TestLogger(t *testing.T) {
 		// Ignore tags with that uses invalid path:
 		{
 			metrics: []Metric{
-				{MatchMessage: regexp.MustCompile("foo"), Name: "a", Tags: map[string][]string{"tag": {"${invalid}"}}},
+				{MatchMessage: regexp.MustCompile("foo"), Name: "a", Tags: map[string][]string{"tag": {"%{invalid}"}}},
 			},
 			want: []want{
 				{name: "a", value: 1},
@@ -250,7 +250,7 @@ func TestLogger(t *testing.T) {
 		// Test all log types except panics:
 		{
 			metrics: []Metric{
-				{MatchMessage: regexp.MustCompile(".*"), Name: "${name}"},
+				{MatchMessage: regexp.MustCompile(".*"), Name: "%{name}"},
 			},
 			want: []want{
 				{name: "debug", value: 1},
@@ -276,7 +276,7 @@ func TestLogger(t *testing.T) {
 		// Test panic:
 		{
 			metrics: []Metric{
-				{MatchMessage: regexp.MustCompile(".*"), Name: "${name}"},
+				{MatchMessage: regexp.MustCompile(".*"), Name: "%{name}"},
 			},
 			want: []want{
 				{name: "panic", value: 1},
@@ -288,7 +288,7 @@ func TestLogger(t *testing.T) {
 		// Test panicf:
 		{
 			metrics: []Metric{
-				{MatchMessage: regexp.MustCompile(".*"), Name: "${name}"},
+				{MatchMessage: regexp.MustCompile(".*"), Name: "%{name}"},
 			},
 			want: []want{
 				{name: "panicf", value: 1},


### PR DESCRIPTION
This enables `%{}` style var interpolations.
Needed for: https://app.shortcut.com/chronicle-labs/story/1076/create-v1-13-0-pre

Story details: https://app.shortcut.com/chronicle-labs/story/1133