### PR TITLE
Fix Teleport replaying mechanism

### DIFF
--- a/pkg/event/publisher/replayer/replayer.go
+++ b/pkg/event/publisher/replayer/replayer.go
@@ -141,6 +141,10 @@ func (r *EventProvider) replayEventsRoutine(ctx context.Context) {
 					for _, from := range r.replayAfter {
 						to := from + now.Sub(last)
 						if age >= from && age < to {
+							// Because the event is a pointer, we need to copy it
+							// to avoid modifying the original event which may be
+							// used somewhere else.
+							evt := evt.Copy()
 							evt.MessageDate = now
 							r.eventCh <- evt
 						}

--- a/pkg/event/publisher/replayer/replayer.go
+++ b/pkg/event/publisher/replayer/replayer.go
@@ -141,6 +141,7 @@ func (r *EventProvider) replayEventsRoutine(ctx context.Context) {
 					for _, from := range r.replayAfter {
 						to := from + now.Sub(last)
 						if age >= from && age < to {
+							evt.MessageDate = now
 							r.eventCh <- evt
 						}
 						if to >= age {

--- a/pkg/event/publisher/replayer/replayer_test.go
+++ b/pkg/event/publisher/replayer/replayer_test.go
@@ -53,7 +53,7 @@ func Test_Replayer(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, rep.Start(ctx))
 
-	evt := &messages.Event{Type: "test", EventDate: time.Now()}
+	evt := &messages.Event{Type: "test", EventDate: time.Now(), MessageDate: time.Now()}
 	ch <- evt
 
 	var count int32
@@ -63,6 +63,7 @@ func Test_Replayer(t *testing.T) {
 			case <-ctx.Done():
 				return
 			case recv := <-rep.Events():
+				assert.Less(t, time.Since(recv.MessageDate), 100*time.Millisecond)
 				assert.Equal(t, evt, recv)
 				atomic.AddInt32(&count, 1)
 			}

--- a/pkg/event/publisher/replayer/replayer_test.go
+++ b/pkg/event/publisher/replayer/replayer_test.go
@@ -53,7 +53,15 @@ func Test_Replayer(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, rep.Start(ctx))
 
-	evt := &messages.Event{Type: "test", EventDate: time.Now(), MessageDate: time.Now()}
+	evt := &messages.Event{
+		Type:        "test",
+		ID:          []byte("test"),
+		Index:       []byte("test"),
+		EventDate:   time.Now(),
+		MessageDate: time.Now(),
+		Data:        map[string][]byte{"test": []byte("test")},
+		Signatures:  map[string]messages.EventSignature{"test": {Signer: []byte("test"), Signature: []byte("test")}},
+	}
 	ch <- evt
 
 	var count int32
@@ -63,8 +71,13 @@ func Test_Replayer(t *testing.T) {
 			case <-ctx.Done():
 				return
 			case recv := <-rep.Events():
+				assert.Equal(t, evt.Type, recv.Type)
+				assert.Equal(t, evt.ID, recv.ID)
+				assert.Equal(t, evt.Index, recv.Index)
+				assert.Equal(t, evt.EventDate, recv.EventDate)
 				assert.Less(t, time.Since(recv.MessageDate), 100*time.Millisecond)
-				assert.Equal(t, evt, recv)
+				assert.Equal(t, evt.Data, recv.Data)
+				assert.Equal(t, evt.Signatures, recv.Signatures)
 				atomic.AddInt32(&count, 1)
 			}
 		}

--- a/pkg/transport/messages/event.go
+++ b/pkg/transport/messages/event.go
@@ -52,6 +52,30 @@ type Event struct {
 	Signatures map[string]EventSignature
 }
 
+// Copy returns a copy of the event.
+func (e *Event) Copy() *Event {
+	evt := &Event{Type: e.Type, EventDate: e.EventDate, MessageDate: e.MessageDate}
+	evt.ID = make([]byte, len(e.ID))
+	evt.Index = make([]byte, len(e.Index))
+	copy(evt.ID, e.ID)
+	copy(evt.Index, e.Index)
+	evt.Data = map[string][]byte{}
+	for k, v := range e.Data {
+		evt.Data[k] = make([]byte, len(v))
+		copy(evt.Data[k], v)
+	}
+	evt.Signatures = map[string]EventSignature{}
+	for k, v := range e.Signatures {
+		evt.Signatures[k] = EventSignature{
+			Signer:    make([]byte, len(v.Signer)),
+			Signature: make([]byte, len(v.Signature)),
+		}
+		copy(evt.Signatures[k].Signer, v.Signer)
+		copy(evt.Signatures[k].Signature, v.Signature)
+	}
+	return evt
+}
+
 // MarshallBinary implements the transport.Message interface.
 func (e *Event) MarshallBinary() ([]byte, error) {
 	signatures := map[string]*pb.Event_Signature{}

--- a/pkg/transport/messages/event_test.go
+++ b/pkg/transport/messages/event_test.go
@@ -25,6 +25,41 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestEvent_Copy(t *testing.T) {
+	event := &Event{
+		Type:        "test",
+		ID:          []byte{10, 10, 10},
+		Index:       []byte{11, 11, 11},
+		EventDate:   time.Unix(12, 0),
+		MessageDate: time.Unix(13, 0),
+		Data: map[string][]byte{
+			"a": {14, 14, 14},
+			"b": {15, 15, 15},
+		},
+		Signatures: map[string]EventSignature{
+			"c": {Signer: []byte{16}, Signature: []byte{16}},
+			"d": {Signer: []byte{17}, Signature: []byte{17}},
+		},
+	}
+
+	copiedEvent := event.Copy()
+
+	assert.Equal(t, event, copiedEvent)
+	assert.NotSame(t, event, copiedEvent)
+	assert.NotSame(t, event.ID, copiedEvent.ID)
+	assert.NotSame(t, event.Index, copiedEvent.Index)
+	assert.NotSame(t, event.Data, copiedEvent.Data)
+	for k, v := range event.Data {
+		assert.NotSame(t, v, copiedEvent.Data[k])
+	}
+	assert.NotSame(t, event.Signatures, copiedEvent.Signatures)
+	for k, v := range event.Signatures {
+		assert.NotSame(t, v, copiedEvent.Signatures[k])
+		assert.NotSame(t, v.Signer, copiedEvent.Signatures[k].Signer)
+		assert.NotSame(t, v.Signature, copiedEvent.Signatures[k].Signature)
+	}
+}
+
 func TestEvent_Marshalling(t *testing.T) {
 	tests := []struct {
 		event   Event


### PR DESCRIPTION
A small fix in the replaying mechanism. The messageDate field was not being updated, so messages were being rejected because they were considered too old.