### PR TITLE
Fix `spire pull prices` command

### DIFF
--- a/pkg/spire/api.go
+++ b/pkg/spire/api.go
@@ -109,6 +109,14 @@ func (n *API) PullPrices(arg *PullPricesArg, resp *PullPricesResp) error {
 				prices = append(prices, price)
 			}
 		}
+	default:
+		allPrices, err := n.priceStore.GetAll(ctx)
+		if err != nil {
+			return err
+		}
+		for _, price := range allPrices {
+			prices = append(prices, price)
+		}
 	}
 
 	*resp = PullPricesResp{Prices: prices}

--- a/pkg/spire/api_test.go
+++ b/pkg/spire/api_test.go
@@ -181,6 +181,23 @@ func TestClient_PullPrices_ByFeeder(t *testing.T) {
 	assertEqualPrices(t, testPriceAAABBB, prices[0])
 }
 
+func TestClient_PullPrices(t *testing.T) {
+	var err error
+	var prices []*messages.Price
+
+	err = spire.PublishPrice(testPriceAAABBB)
+	assert.NoError(t, err)
+
+	wait(func() bool {
+		prices, err = spire.PullPrices("", "")
+		return len(prices) != 0
+	}, time.Second)
+
+	assert.NoError(t, err)
+	assert.Len(t, prices, 1)
+	assertEqualPrices(t, testPriceAAABBB, prices[0])
+}
+
 func assertEqualPrices(t *testing.T, expected, given *messages.Price) {
 	je, _ := json.Marshal(expected)
 	jg, _ := json.Marshal(given)


### PR DESCRIPTION
The `spire pull prices` command should return all prices when no filters are specified. 