### PR TITLE
Updated tools documentation to use `go install`

### DIFF
--- a/cmd/gofer/README.md
+++ b/cmd/gofer/README.md
@@ -22,7 +22,7 @@ exactly, from how many sources you want to pull prices and what conditions they 
 ## Installation
 
 To install it, you'll first need Go installed on your machine. Then you can use standard Go
-command: `go get -u github.com/chronicleprotocol/oracle-suite/cmd/gofer`.
+command: `go install github.com/chronicleprotocol/oracle-suite/cmd/gofer@latest`
 
 Alternatively, you can build Gofer using `Makefile` directly from the repository. This approach is recommended if you
 wish to work on Gofer source.

--- a/cmd/keeman/README.md
+++ b/cmd/keeman/README.md
@@ -3,6 +3,6 @@ The Keymaker
 This is a simple tool for creating various types of encryption keys.
 
 ```shell
-go get -u github.com/chronicleprotocol/oracle-suite/cmd/keeman
+go install github.com/chronicleprotocol/oracle-suite/cmd/keeman@latest
 ```
 

--- a/cmd/lair/README.md
+++ b/cmd/lair/README.md
@@ -16,7 +16,7 @@ Lair is one of the components of Maker Teleport: https://forum.makerdao.com/t/in
 ## Installation
 
 To install it, you'll first need Go installed on your machine. Then you can use standard Go
-command: `go get -u github.com/chronicleprotocol/oracle-suite/cmd/lair`.
+command: `go install github.com/chronicleprotocol/oracle-suite/cmd/lair@latest`
 
 Alternatively, you can build Lair using `Makefile` directly from the repository. This approach is recommended if you
 wish to work on Lair source.

--- a/cmd/leeloo/README.md
+++ b/cmd/leeloo/README.md
@@ -16,10 +16,10 @@ Leeloo is one of the components of Maker Teleport: https://forum.makerdao.com/t/
 ## Installation
 
 To install it, you'll first need Go installed on your machine. Then you can use standard Go
-command: `go get -u github.com/chronicleprotocol/oracle-suite/cmd/leeloo`.
+command: `go install github.com/chronicleprotocol/oracle-suite/cmd/leeloo@latest`
 
-Alternatively, you can build Gofer using `Makefile` directly from the repository. This approach is recommended if you
-wish to work on Gofer source.
+Alternatively, you can build Leeloo using `Makefile` directly from the repository. This approach is recommended if 
+you wish to work on Leeloo source.
 
 ```bash
 git clone https://github.com/chronicleprotocol/oracle-suite.git

--- a/cmd/rpc-splitter/README.md
+++ b/cmd/rpc-splitter/README.md
@@ -15,7 +15,7 @@ to guarantee data integrity.
 ## Installation
 
 To install it, you'll first need Go installed on your machine. Then you can use standard Go
-command: `go get -u github.com/chronicleprotocol/oracle-suite/cmd/rpc-splitter`.
+command: `go install github.com/chronicleprotocol/oracle-suite/cmd/rpc-splitter@latest`
 
 Alternatively, you can build RPC-Splitter using `Makefile` directly from the repository. This approach is recommended if
 you wish to work on RPC-Splitter source.

--- a/cmd/spire-bootstrap/README.md
+++ b/cmd/spire-bootstrap/README.md
@@ -12,7 +12,7 @@ Spire-Bootstrap starts the libp2p bootstrap node for the Spire network.
 ## Installation
 
 To install it, you'll first need Go installed on your machine. Then you can use standard Go
-command: `go get -u github.com/chronicleprotocol/oracle-suite/cmd/spire-bootstrap`.
+command: `go install github.com/chronicleprotocol/oracle-suite/cmd/spire-bootstrap@latest`
 
 Alternatively, you can build Spire-Bootstrap using `Makefile` directly from the repository. This approach is recommended
 if you

--- a/cmd/spire/README.md
+++ b/cmd/spire/README.md
@@ -14,10 +14,10 @@ of [libp2p](https://libp2p.io/).
 ## Installation
 
 To install it, you'll first need Go installed on your machine. Then you can use standard Go
-command: `go get -u github.com/chronicleprotocol/oracle-suite/cmd/spire`.
+command: `go install github.com/chronicleprotocol/oracle-suite/cmd/spire@latest`
 
-Alternatively, you can build Gofer using `Makefile` directly from the repository. This approach is recommended if you
-wish to work on Gofer source.
+Alternatively, you can build Spire using `Makefile` directly from the repository. This approach is recommended if you
+wish to work on Spire source.
 
 ```bash
 git clone https://github.com/chronicleprotocol/oracle-suite.git


### PR DESCRIPTION
It seems that the method of using `go` to install our tools has changed since our documentation was first created. The old method, `go get -u [url]` has been superseded by `go install [url]@[version]`, so I updated all README.md installation procedures to reflect the new format.

Additionally, I cleaned up a bit of copypasta that referenced the Gofer tool in other README files.