### PR TITLE
Improve tests stability [sc-2167]

### DIFF
--- a/pkg/event/api/api_test.go
+++ b/pkg/event/api/api_test.go
@@ -61,6 +61,9 @@ func TestEventAPI(t *testing.T) {
 		require.NoError(t, <-api.Wait())
 	}()
 
+	// Wait for services to start.
+	time.Sleep(time.Millisecond * 100)
+
 	require.NoError(t, loc.Broadcast(messages.EventV1MessageName, &messages.Event{
 		Type:        "event1",
 		ID:          []byte("id1"),
@@ -98,7 +101,8 @@ func TestEventAPI(t *testing.T) {
 		Signatures:  map[string]messages.EventSignature{"sig_key": {Signer: []byte("val"), Signature: []byte("val")}},
 	}))
 
-	time.Sleep(time.Second)
+	// Wait for events to be processed.
+	time.Sleep(time.Millisecond * 100)
 
 	// Test idx1 without 0x prefix:
 	res, err := http.Get(fmt.Sprintf("http://%s?type=event1&index=%x", api.srv.Addr().String(), "idx1"))

--- a/pkg/price/feeder/feeder_test.go
+++ b/pkg/price/feeder/feeder_test.go
@@ -181,6 +181,9 @@ func TestFeeder_Broadcast(t *testing.T) {
 				<-localTransport.Wait()
 			}()
 
+			// Wait for service to start.
+			time.Sleep(time.Millisecond * 100)
+
 			ticker.Tick()
 
 			// Wait for two messages.
@@ -189,10 +192,18 @@ func TestFeeder_Broadcast(t *testing.T) {
 			v1ch := localTransport.Messages(messages.PriceV1MessageName)
 			for {
 				select {
-				case msg := <-v0ch:
+				case msg, ok := <-v0ch:
+					if !ok {
+						require.Fail(t, "v0 channel closed")
+						continue
+					}
 					price := msg.Message.(*messages.Price)
 					pricesV0 = append(pricesV0, price)
-				case msg := <-v1ch:
+				case msg, ok := <-v1ch:
+					if !ok {
+						require.Fail(t, "v1 channel closed")
+						continue
+					}
 					price := msg.Message.(*messages.Price)
 					pricesV1 = append(pricesV1, price)
 				}


### PR DESCRIPTION
It fixes two race conditions in tests. Sometimes, a service may take a little longer to start, and the test code may try to use it before it's ready. I've added a `time.Sleep` for now, but I think that a better approach would be to update the `supervisor.Start` method to wait for services to start. However, since we don't need to wait for services to start outside of tests, it is not a priority.