### PR TITLE
Marshal/Unmarshal nil value

### DIFF
--- a/config-gofernext.hcl
+++ b/config-gofernext.hcl
@@ -54,7 +54,7 @@ gofernext {
   origin "gemini" {
     type = "tick_generic_jq"
     url  = "https://api.gemini.com/v1/pubticker/$${lcbase}$${lcquote}"
-    jq   = "{price: .last, time: (.volume.timestamp/1000), volume: null}"
+    jq   = "{price: .last, time: (.volume.timestamp/1000), volume: .volume[$ucquote]|tonumber}"
   }
 
   origin "huobi" {


### PR DESCRIPTION
### Description of pull request:

- Marshal/unmarshal nil value of `volume24h`
- Return volume for `gemini` origin
- Fix invalid calculation of price when marshal in binary
- Add Unit test of marshal/unmarshal in binary/json

### Reason of error

- Web3 origins are not available to provide volume for last 24 hour, that makes `volume24h` `nil`
- Failed on marshaling nil value