### PR TITLE
Use DecFloatPoint instead of Float [sc-2943]

### DIFF
--- a/cmd/gofer/cmd_data.go
+++ b/cmd/gofer/cmd_data.go
@@ -58,11 +58,11 @@ func NewDataCmd(c supervisor.Config, f *cmd.FilesFlags, l *cmd.LoggerFlags) *cob
 			if !ok {
 				return fmt.Errorf("services are not gofer.Services")
 			}
-			ticks, err := s.DataProvider.DataPoints(ctx, getModelsNames(ctx, s.DataProvider, args)...)
+			points, err := s.DataProvider.DataPoints(ctx, getModelsNames(ctx, s.DataProvider, args)...)
 			if err != nil {
 				return err
 			}
-			marshaled, err := marshalDataPoints(ticks, format.String())
+			marshaled, err := marshalDataPoints(points, format.String())
 			if err != nil {
 				return err
 			}

--- a/pkg/config/feednext/feed.go
+++ b/pkg/config/feednext/feed.go
@@ -33,8 +33,8 @@ import (
 )
 
 const (
-	tickPriceBroadcastPrecision  = 18
-	tickVolumeBroadcastPrecision = 18
+	tickPriceBroadcastMaxPrecision  = 18
+	tickVolumeBroadcastMaxPrecision = 18
 )
 
 type Config struct {
@@ -83,7 +83,7 @@ func (c *Config) ConfigureFeed(d Dependencies) (*feed.Feed, error) {
 		}
 	}
 	hooks := []feed.Hook{
-		feed.NewTickPrecisionHook(tickPriceBroadcastPrecision, tickVolumeBroadcastPrecision),
+		feed.NewTickPrecisionHook(tickPriceBroadcastMaxPrecision, tickVolumeBroadcastMaxPrecision),
 		feed.NewTickTraceHook(),
 	}
 	cfg := feed.Config{

--- a/pkg/config/feednext/feed.go
+++ b/pkg/config/feednext/feed.go
@@ -32,6 +32,11 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/util/timeutil"
 )
 
+const (
+	tickPriceBroadcastPrecision  = 18
+	tickVolumeBroadcastPrecision = 18
+)
+
 type Config struct {
 	// EthereumKey is the name of the Ethereum key to use for signing prices.
 	EthereumKey string `hcl:"ethereum_key"`
@@ -77,13 +82,18 @@ func (c *Config) ConfigureFeed(d Dependencies) (*feed.Feed, error) {
 			Subject:  c.Content.Attributes["ethereum_key"].Range.Ptr(),
 		}
 	}
+	hooks := []feed.Hook{
+		feed.NewTickPrecisionHook(tickPriceBroadcastPrecision, tickVolumeBroadcastPrecision),
+		feed.NewTickTraceHook(),
+	}
 	cfg := feed.Config{
 		DataModels:   c.DataModels,
 		DataProvider: d.DataProvider,
 		Signers:      []datapoint.Signer{signer.NewTickSigner(ethereumKey)},
+		Hooks:        hooks,
 		Transport:    d.Transport,
-		Logger:       d.Logger,
 		Interval:     timeutil.NewTicker(time.Second * time.Duration(c.Interval)),
+		Logger:       d.Logger,
 	}
 	feedService, err := feed.New(cfg)
 	if err != nil {

--- a/pkg/contract/median.go
+++ b/pkg/contract/median.go
@@ -134,8 +134,8 @@ func (m *Median) Poke(ctx context.Context, vals []MedianVal) (*types.Hash, *type
 	rSlice := make([]*big.Int, len(vals))
 	sSlice := make([]*big.Int, len(vals))
 	for i, v := range vals {
-		if v.Val.Precision() != MedianPricePrecision {
-			return nil, nil, fmt.Errorf("median: poke failed: invalid precision: %d", v.Val.Precision())
+		if v.Val.Prec() != MedianPricePrecision {
+			return nil, nil, fmt.Errorf("median: poke failed: invalid precision: %d", v.Val.Prec())
 		}
 		valSlice[i] = v.Val.RawBigInt()
 		ageSlice[i] = uint64(v.Age.Unix())

--- a/pkg/datapoint/datapoint.go
+++ b/pkg/datapoint/datapoint.go
@@ -205,7 +205,7 @@ func (p Point) MarshalTrace() ([]byte, error) {
 		meta := make(map[string]any)
 		point := node.(Point)
 		typ := "data_point"
-		meta["value"] = point.Value
+		meta["value"] = point.Value.Print()
 		meta["time"] = point.Time.In(time.UTC).Format(time.RFC3339Nano)
 		var points []any
 		for _, t := range point.SubPoints {

--- a/pkg/datapoint/graph/dev_circuit_breaker.go
+++ b/pkg/datapoint/graph/dev_circuit_breaker.go
@@ -124,15 +124,15 @@ func (n *DevCircuitBreakerNode) DataPoint() datapoint.Point {
 	meta := n.Meta()
 
 	// Calculate deviation.
-	deviation := bn.Float(1.0).Sub(refValue.Number().Div(valueValue.Number())).Abs().Float64()
+	deviation := bn.Float(1.0).Sub(refValue.Number().Div(valueValue.Number())).Abs().BigFloat()
 	meta["deviation"] = deviation
-	meta["threshold"] = thresholdValue.Number().Float64()
+	meta["threshold"] = thresholdValue.Number().BigFloat()
 
 	// Return tick, if deviation is greater than threshold, add error.
 	point := valuePoint
 	point.SubPoints = []datapoint.Point{n.valueNode.DataPoint(), n.referenceNode.DataPoint()}
 	point.Meta = meta
-	if deviation > thresholdValue.Number().Float64() {
+	if deviation.Cmp(thresholdValue.Number().BigFloat()) > 0 {
 		point.Error = fmt.Errorf("deviation %f is greater than threshold %s", deviation, thresholdValue.Number())
 	}
 	return point

--- a/pkg/datapoint/graph/tick_alias_test.go
+++ b/pkg/datapoint/graph/tick_alias_test.go
@@ -15,19 +15,15 @@ import (
 func TestTickAliasNode_DataPoint(t *testing.T) {
 	mockNode := new(mockNode)
 	mockNode.On("DataPoint").Return(datapoint.Point{
-		Value: value.Tick{
-			Pair:      value.Pair{Base: "BTC", Quote: "USDC"},
-			Price:     bn.Float(20000),
-			Volume24h: bn.Float(2),
-		},
+		Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USDC"}, 20000, 2),
 	})
 	node := NewTickAliasNode(value.Pair{Base: "BTC", Quote: "USD"})
 	require.NoError(t, node.AddNodes(mockNode))
 	tick := node.DataPoint().Value.(value.Tick)
 	assert.Equal(t, "BTC", tick.Pair.Base)
 	assert.Equal(t, "USD", tick.Pair.Quote)
-	assert.Equal(t, bn.Float(20000).Float64(), tick.Price.Float64())
-	assert.Equal(t, bn.Float(2).Float64(), tick.Volume24h.Float64())
+	assert.Equal(t, bn.DecFloatPoint(20000).String(), tick.Price.String())
+	assert.Equal(t, bn.DecFloatPoint(2).String(), tick.Volume24h.String())
 }
 
 func TestTickAliasNode_AddNodes(t *testing.T) {

--- a/pkg/datapoint/graph/tick_indirect.go
+++ b/pkg/datapoint/graph/tick_indirect.go
@@ -93,7 +93,7 @@ func crossRate(points []datapoint.Point) (datapoint.Point, error) {
 		bt := bp.Value.(value.Tick)
 		var (
 			pair  value.Pair
-			price *bn.FloatNumber
+			price *bn.DecFixedPointNumber
 		)
 		switch {
 		case at.Pair.Quote == bt.Pair.Quote: // A/C, B/C
@@ -102,7 +102,7 @@ func crossRate(points []datapoint.Point) (datapoint.Point, error) {
 			if bt.Price.Sign() > 0 {
 				price = at.Price.Div(bt.Price)
 			} else {
-				price = bn.Float(0)
+				price = bn.DecFixedPoint(0, at.Price.Precision())
 			}
 		case at.Pair.Base == bt.Pair.Base: // C/A, C/B
 			pair.Base = at.Pair.Quote
@@ -110,7 +110,7 @@ func crossRate(points []datapoint.Point) (datapoint.Point, error) {
 			if at.Price.Sign() > 0 {
 				price = bt.Price.Div(at.Price)
 			} else {
-				price = bn.Float(0)
+				price = bn.DecFixedPoint(0, at.Price.Precision())
 			}
 		case at.Pair.Quote == bt.Pair.Base: // A/C, C/B
 			pair.Base = at.Pair.Base
@@ -120,9 +120,9 @@ func crossRate(points []datapoint.Point) (datapoint.Point, error) {
 			pair.Base = at.Pair.Quote
 			pair.Quote = bt.Pair.Base
 			if at.Price.Sign() > 0 && bt.Price.Sign() > 0 {
-				price = bn.Float(1).Div(bt.Price).Div(at.Price)
+				price = bt.Price.Inv().Div(at.Price)
 			} else {
-				price = bn.Float(0)
+				price = bn.DecFixedPoint(0, at.Price.Precision())
 			}
 		default:
 			return ap, fmt.Errorf("unable to calculate cross rate for %s and %s", at.Pair, bt.Pair)

--- a/pkg/datapoint/graph/tick_indirect.go
+++ b/pkg/datapoint/graph/tick_indirect.go
@@ -93,7 +93,7 @@ func crossRate(points []datapoint.Point) (datapoint.Point, error) {
 		bt := bp.Value.(value.Tick)
 		var (
 			pair  value.Pair
-			price *bn.DecFixedPointNumber
+			price *bn.DecFloatPointNumber
 		)
 		switch {
 		case at.Pair.Quote == bt.Pair.Quote: // A/C, B/C
@@ -102,7 +102,7 @@ func crossRate(points []datapoint.Point) (datapoint.Point, error) {
 			if bt.Price.Sign() > 0 {
 				price = at.Price.Div(bt.Price)
 			} else {
-				price = bn.DecFixedPoint(0, at.Price.Prec())
+				price = bn.DecFloatPoint(0)
 			}
 		case at.Pair.Base == bt.Pair.Base: // C/A, C/B
 			pair.Base = at.Pair.Quote
@@ -110,7 +110,7 @@ func crossRate(points []datapoint.Point) (datapoint.Point, error) {
 			if at.Price.Sign() > 0 {
 				price = bt.Price.Div(at.Price)
 			} else {
-				price = bn.DecFixedPoint(0, at.Price.Prec())
+				price = bn.DecFloatPoint(0)
 			}
 		case at.Pair.Quote == bt.Pair.Base: // A/C, C/B
 			pair.Base = at.Pair.Base
@@ -122,7 +122,7 @@ func crossRate(points []datapoint.Point) (datapoint.Point, error) {
 			if at.Price.Sign() > 0 && bt.Price.Sign() > 0 {
 				price = bt.Price.Inv().Div(at.Price)
 			} else {
-				price = bn.DecFixedPoint(0, at.Price.Prec())
+				price = bn.DecFloatPoint(0)
 			}
 		default:
 			return ap, fmt.Errorf("unable to calculate cross rate for %s and %s", at.Pair, bt.Pair)

--- a/pkg/datapoint/graph/tick_indirect.go
+++ b/pkg/datapoint/graph/tick_indirect.go
@@ -102,7 +102,7 @@ func crossRate(points []datapoint.Point) (datapoint.Point, error) {
 			if bt.Price.Sign() > 0 {
 				price = at.Price.Div(bt.Price)
 			} else {
-				price = bn.DecFixedPoint(0, at.Price.Precision())
+				price = bn.DecFixedPoint(0, at.Price.Prec())
 			}
 		case at.Pair.Base == bt.Pair.Base: // C/A, C/B
 			pair.Base = at.Pair.Quote
@@ -110,7 +110,7 @@ func crossRate(points []datapoint.Point) (datapoint.Point, error) {
 			if at.Price.Sign() > 0 {
 				price = bt.Price.Div(at.Price)
 			} else {
-				price = bn.DecFixedPoint(0, at.Price.Precision())
+				price = bn.DecFixedPoint(0, at.Price.Prec())
 			}
 		case at.Pair.Quote == bt.Pair.Base: // A/C, C/B
 			pair.Base = at.Pair.Base
@@ -122,7 +122,7 @@ func crossRate(points []datapoint.Point) (datapoint.Point, error) {
 			if at.Price.Sign() > 0 && bt.Price.Sign() > 0 {
 				price = bt.Price.Inv().Div(at.Price)
 			} else {
-				price = bn.DecFixedPoint(0, at.Price.Precision())
+				price = bn.DecFixedPoint(0, at.Price.Prec())
 			}
 		default:
 			return ap, fmt.Errorf("unable to calculate cross rate for %s and %s", at.Pair, bt.Pair)

--- a/pkg/datapoint/graph/tick_indirect_test.go
+++ b/pkg/datapoint/graph/tick_indirect_test.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint"
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint/value"
-
-	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 func TestTickIndirectNode(t *testing.T) {
@@ -25,15 +23,15 @@ func TestTickIndirectNode(t *testing.T) {
 			name: "three nodes",
 			points: []datapoint.Point{
 				{
-					Value: value.Tick{Pair: value.Pair{Base: "A", Quote: "B"}, Price: bn.Float(1)},
+					Value: value.NewTick(value.Pair{Base: "A", Quote: "B"}, 1, 0),
 					Time:  time.Now(),
 				},
 				{
-					Value: value.Tick{Pair: value.Pair{Base: "B", Quote: "C"}, Price: bn.Float(2)},
+					Value: value.NewTick(value.Pair{Base: "B", Quote: "C"}, 2, 0),
 					Time:  time.Now(),
 				},
 				{
-					Value: value.Tick{Pair: value.Pair{Base: "C", Quote: "D"}, Price: bn.Float(3)},
+					Value: value.NewTick(value.Pair{Base: "C", Quote: "D"}, 3, 0),
 					Time:  time.Now(),
 				},
 			},
@@ -45,11 +43,11 @@ func TestTickIndirectNode(t *testing.T) {
 			name: "A/B->B/C",
 			points: []datapoint.Point{
 				{
-					Value: value.Tick{Pair: value.Pair{Base: "A", Quote: "B"}, Price: bn.Float(1)},
+					Value: value.NewTick(value.Pair{Base: "A", Quote: "B"}, 1, 0),
 					Time:  time.Now(),
 				},
 				{
-					Value: value.Tick{Pair: value.Pair{Base: "B", Quote: "C"}, Price: bn.Float(2)},
+					Value: value.NewTick(value.Pair{Base: "B", Quote: "C"}, 2, 0),
 					Time:  time.Now(),
 				},
 			},
@@ -61,11 +59,11 @@ func TestTickIndirectNode(t *testing.T) {
 			name: "B/A->B/C",
 			points: []datapoint.Point{
 				{
-					Value: value.Tick{Pair: value.Pair{Base: "B", Quote: "A"}, Price: bn.Float(1)},
+					Value: value.NewTick(value.Pair{Base: "B", Quote: "A"}, 1, 0),
 					Time:  time.Now(),
 				},
 				{
-					Value: value.Tick{Pair: value.Pair{Base: "B", Quote: "C"}, Price: bn.Float(2)},
+					Value: value.NewTick(value.Pair{Base: "B", Quote: "C"}, 2, 0),
 					Time:  time.Now(),
 				},
 			},
@@ -77,11 +75,11 @@ func TestTickIndirectNode(t *testing.T) {
 			name: "A/B->C/B",
 			points: []datapoint.Point{
 				{
-					Value: value.Tick{Pair: value.Pair{Base: "A", Quote: "B"}, Price: bn.Float(1)},
+					Value: value.NewTick(value.Pair{Base: "A", Quote: "B"}, 1, 0),
 					Time:  time.Now(),
 				},
 				{
-					Value: value.Tick{Pair: value.Pair{Base: "C", Quote: "B"}, Price: bn.Float(2)},
+					Value: value.NewTick(value.Pair{Base: "C", Quote: "B"}, 2, 0),
 					Time:  time.Now(),
 				},
 			},
@@ -93,11 +91,11 @@ func TestTickIndirectNode(t *testing.T) {
 			name: "B/A->C/B",
 			points: []datapoint.Point{
 				{
-					Value: value.Tick{Pair: value.Pair{Base: "B", Quote: "A"}, Price: bn.Float(1)},
+					Value: value.NewTick(value.Pair{Base: "B", Quote: "A"}, 1, 0),
 					Time:  time.Now(),
 				},
 				{
-					Value: value.Tick{Pair: value.Pair{Base: "C", Quote: "B"}, Price: bn.Float(2)},
+					Value: value.NewTick(value.Pair{Base: "C", Quote: "B"}, 2, 0),
 					Time:  time.Now(),
 				},
 			},
@@ -119,7 +117,8 @@ func TestTickIndirectNode(t *testing.T) {
 
 			// Test
 			point := node.DataPoint()
-			assert.Equal(t, tt.expectedPrice, point.Value.(value.NumericValue).Number().Float64())
+			price, _ := point.Value.(value.NumericValue).Number().BigFloat().Float64()
+			assert.Equal(t, tt.expectedPrice, price)
 			if tt.wantErr {
 				assert.Error(t, point.Validate())
 			} else {

--- a/pkg/datapoint/graph/tick_invert_test.go
+++ b/pkg/datapoint/graph/tick_invert_test.go
@@ -15,19 +15,15 @@ import (
 func TestTickInvertNode_DataPoint(t *testing.T) {
 	mockNode := new(mockNode)
 	mockNode.On("DataPoint").Return(datapoint.Point{
-		Value: value.Tick{
-			Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-			Price:     bn.Float(20000),
-			Volume24h: bn.Float(2),
-		},
+		Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 20000, 2),
 	})
 	node := NewTickInvertNode()
 	require.NoError(t, node.AddNodes(mockNode))
 	tick := node.DataPoint().Value.(value.Tick)
 	assert.Equal(t, "USD", tick.Pair.Base)
 	assert.Equal(t, "BTC", tick.Pair.Quote)
-	assert.Equal(t, bn.Float(0.00005).Float64(), tick.Price.Float64())
-	assert.Equal(t, bn.Float(40000).Float64(), tick.Volume24h.Float64())
+	assert.Equal(t, bn.DecFloatPoint(0.00005).String(), tick.Price.String())
+	assert.Equal(t, bn.DecFloatPoint(40000).String(), tick.Volume24h.String())
 }
 
 func TestTickInvertNode_AddNodes(t *testing.T) {

--- a/pkg/datapoint/graph/tick_median.go
+++ b/pkg/datapoint/graph/tick_median.go
@@ -137,7 +137,7 @@ func median(xs []*bn.DecFixedPointNumber) *bn.DecFixedPointNumber {
 		m := count / 2
 		x1 := xs[m-1]
 		x2 := xs[m]
-		return x1.Add(x2).Div(bn.Float(2))
+		return x1.Add(x2).Div(bn.DecFixedPoint(2, 0))
 	}
 	return xs[(count-1)/2]
 }

--- a/pkg/datapoint/graph/tick_median.go
+++ b/pkg/datapoint/graph/tick_median.go
@@ -62,7 +62,7 @@ func (n *TickMedianNode) DataPoint() datapoint.Point {
 		tm     time.Time
 		points []datapoint.Point
 		ticks  []value.Tick
-		prices []*bn.DecFixedPointNumber
+		prices []*bn.DecFloatPointNumber
 	)
 
 	// Collect all data points from nodes and that can be used to calculate
@@ -125,7 +125,7 @@ func (n *TickMedianNode) Meta() map[string]any {
 	}
 }
 
-func median(xs []*bn.DecFixedPointNumber) *bn.DecFixedPointNumber {
+func median(xs []*bn.DecFloatPointNumber) *bn.DecFloatPointNumber {
 	count := len(xs)
 	if count == 0 {
 		return nil
@@ -137,7 +137,7 @@ func median(xs []*bn.DecFixedPointNumber) *bn.DecFixedPointNumber {
 		m := count / 2
 		x1 := xs[m-1]
 		x2 := xs[m]
-		return x1.Add(x2).Div(bn.DecFixedPoint(2, 0))
+		return x1.Add(x2).Div(bn.DecFloatPoint(2))
 	}
 	return xs[(count-1)/2]
 }

--- a/pkg/datapoint/graph/tick_median.go
+++ b/pkg/datapoint/graph/tick_median.go
@@ -62,7 +62,7 @@ func (n *TickMedianNode) DataPoint() datapoint.Point {
 		tm     time.Time
 		points []datapoint.Point
 		ticks  []value.Tick
-		prices []*bn.FloatNumber
+		prices []*bn.DecFixedPointNumber
 	)
 
 	// Collect all data points from nodes and that can be used to calculate
@@ -110,11 +110,7 @@ func (n *TickMedianNode) DataPoint() datapoint.Point {
 
 	// Return median tick.
 	return datapoint.Point{
-		Value: value.Tick{
-			Pair:      ticks[0].Pair,
-			Price:     median(prices),
-			Volume24h: bn.Float(0),
-		},
+		Value:     value.NewTick(ticks[0].Pair, median(prices), 0),
 		Time:      tm,
 		SubPoints: points,
 		Meta:      n.Meta(),
@@ -129,7 +125,7 @@ func (n *TickMedianNode) Meta() map[string]any {
 	}
 }
 
-func median(xs []*bn.FloatNumber) *bn.FloatNumber {
+func median(xs []*bn.DecFixedPointNumber) *bn.DecFixedPointNumber {
 	count := len(xs)
 	if count == 0 {
 		return nil

--- a/pkg/datapoint/graph/tick_median_test.go
+++ b/pkg/datapoint/graph/tick_median_test.go
@@ -19,99 +19,67 @@ func TestTickMedianNode(t *testing.T) {
 		name          string
 		points        []datapoint.Point
 		minValues     int
-		expectedValue *bn.FloatNumber
+		expectedValue *bn.DecFloatPointNumber
 		wantErr       bool
 	}{
 		{
 			name: "one value",
 			points: []datapoint.Point{
 				{
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "A", Quote: "B"},
-						Price:     bn.Float(1),
-						Volume24h: bn.Float(1),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "A", Quote: "B"}, 1, 1),
+					Time:  time.Now(),
 				},
 			},
 			minValues:     1,
-			expectedValue: bn.Float(1),
+			expectedValue: bn.DecFloatPoint(1),
 			wantErr:       false,
 		},
 		{
 			name: "two values",
 			points: []datapoint.Point{
 				{
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "A", Quote: "B"},
-						Price:     bn.Float(1),
-						Volume24h: bn.Float(1),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "A", Quote: "B"}, 1, 1),
+					Time:  time.Now(),
 				},
 				{
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "A", Quote: "B"},
-						Price:     bn.Float(2),
-						Volume24h: bn.Float(2),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "A", Quote: "B"}, 2, 2),
+					Time:  time.Now(),
 				},
 			},
 			minValues:     2,
-			expectedValue: bn.Float(1.5),
+			expectedValue: bn.DecFloatPoint(1.5),
 			wantErr:       false,
 		},
 		{
 			name: "three values",
 			points: []datapoint.Point{
 				{
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "A", Quote: "B"},
-						Price:     bn.Float(1),
-						Volume24h: bn.Float(1),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "A", Quote: "B"}, 1, 1),
+					Time:  time.Now(),
 				},
 				{
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "A", Quote: "B"},
-						Price:     bn.Float(2),
-						Volume24h: bn.Float(2),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "A", Quote: "B"}, 2, 2),
+					Time:  time.Now(),
 				},
 				{
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "A", Quote: "B"},
-						Price:     bn.Float(3),
-						Volume24h: bn.Float(3),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "A", Quote: "B"}, 3, 3),
+					Time:  time.Now(),
 				},
 			},
 			minValues:     3,
-			expectedValue: bn.Float(2),
+			expectedValue: bn.DecFloatPoint(2),
 			wantErr:       false,
 		},
 		{
 			name: "not enough values",
 			points: []datapoint.Point{
 				{
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "A", Quote: "B"},
-						Price:     bn.Float(1),
-						Volume24h: bn.Float(1),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "A", Quote: "B"}, 1, 1),
+					Time:  time.Now(),
 				},
 				{
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "A", Quote: "B"},
-						Price:     bn.Float(2),
-						Volume24h: bn.Float(2),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "A", Quote: "B"}, 2, 2),
+					Time:  time.Now(),
 				},
 				{
 					Time:  time.Now(),
@@ -125,20 +93,12 @@ func TestTickMedianNode(t *testing.T) {
 			name: "different pairs",
 			points: []datapoint.Point{
 				{
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "A", Quote: "B"},
-						Price:     bn.Float(1),
-						Volume24h: bn.Float(1),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "A", Quote: "B"}, 1, 1),
+					Time:  time.Now(),
 				},
 				{
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "B", Quote: "A"},
-						Price:     bn.Float(2),
-						Volume24h: bn.Float(2),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "B", Quote: "A"}, 2, 2),
+					Time:  time.Now(),
 				},
 			},
 			minValues: 2,
@@ -161,7 +121,9 @@ func TestTickMedianNode(t *testing.T) {
 			if tt.wantErr {
 				assert.Error(t, point.Validate())
 			} else {
-				assert.Equal(t, tt.expectedValue.Float64(), point.Value.(value.NumericValue).Number().Float64())
+				expValue, _ := tt.expectedValue.BigFloat().Float64()
+				value, _ := point.Value.(value.NumericValue).Number().BigFloat().Float64()
+				assert.Equal(t, expValue, value)
 				require.NoError(t, point.Validate())
 			}
 		})

--- a/pkg/datapoint/origin/balancer_v2.go
+++ b/pkg/datapoint/origin/balancer_v2.go
@@ -30,7 +30,6 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/ethereum"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log/null"
-	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 const BalancerV2LoggerTag = "BALANCERV2_ORIGIN"
@@ -180,11 +179,7 @@ func (b *BalancerV2) FetchDataPoints(ctx context.Context, query []any) (map[any]
 			avgPrice = new(big.Float).Quo(new(big.Float).SetUint64(1), avgPrice)
 		}
 
-		tick := value.Tick{
-			Pair:      pair,
-			Price:     bn.Float(avgPrice),
-			Volume24h: nil,
-		}
+		tick := value.NewTick(pair, avgPrice, nil)
 		points[pair] = datapoint.Point{
 			Value: tick,
 			Time:  time.Now(),

--- a/pkg/datapoint/origin/balancerv2_test.go
+++ b/pkg/datapoint/origin/balancerv2_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint/value"
 	ethereumMocks "github.com/chronicleprotocol/oracle-suite/pkg/ethereum/mocks"
+	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 type BalancerV2Suite struct {
@@ -126,14 +127,14 @@ func (suite *BalancerV2Suite) TestSuccessResponse() {
 	pair := value.Pair{Base: "STETH", Quote: "WETH"}
 	points, err := suite.origin.FetchDataPoints(ctx, []any{pair})
 	suite.Require().NoError(err)
-	suite.Equal(0.97, points[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(0.97).String(), points[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(points[pair].Time.Unix(), int64(0))
 
 	// Inverted pair
 	pair = value.Pair{Base: "WETH", Quote: "STETH"}
 	points, err = suite.origin.FetchDataPoints(context.Background(), []any{pair})
 	suite.Require().NoError(err)
-	suite.Equal(1/0.97, points[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(1/0.97).String(), points[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(points[pair].Time.Unix(), int64(0))
 }
 
@@ -215,14 +216,14 @@ func (suite *BalancerV2Suite) TestSuccessResponseWithRef() {
 	pair := value.Pair{Base: "RETH", Quote: "WETH"}
 	points, err := suite.origin.FetchDataPoints(ctx, []any{pair})
 	suite.Require().NoError(err)
-	suite.Equal(0.485, points[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(0.485).String(), points[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(points[pair].Time.Unix(), int64(0))
 
 	// Inverted pair
 	pair = value.Pair{Base: "WETH", Quote: "RETH"}
 	points, err = suite.origin.FetchDataPoints(context.Background(), []any{pair})
 	suite.Require().NoError(err)
-	suite.Equal(1/0.485, points[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(1/0.485).String(), points[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(points[pair].Time.Unix(), int64(0))
 }
 

--- a/pkg/datapoint/origin/curve.go
+++ b/pkg/datapoint/origin/curve.go
@@ -32,7 +32,6 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/ethereum"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log/null"
-	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 const CurveLoggerTag = "CURVE_ORIGIN"
@@ -249,11 +248,7 @@ func (c *Curve) fetchDataPoints(
 			avgPrice = new(big.Float).Quo(new(big.Float).SetUint64(1), avgPrice)
 		}
 
-		tick := value.Tick{
-			Pair:      pair,
-			Price:     bn.Float(avgPrice),
-			Volume24h: nil,
-		}
+		tick := value.NewTick(pair, avgPrice, nil)
 		points[pair] = datapoint.Point{
 			Value: tick,
 			Time:  time.Now(),

--- a/pkg/datapoint/origin/curve_test.go
+++ b/pkg/datapoint/origin/curve_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint/value"
 	ethereumMocks "github.com/chronicleprotocol/oracle-suite/pkg/ethereum/mocks"
+	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 type CurveSuite struct {
@@ -151,7 +152,7 @@ func (suite *CurveSuite) TestSuccessResponse() {
 	pair := value.Pair{Base: "ETH", Quote: "STETH"}
 	points, err := suite.origin.FetchDataPoints(context.Background(), []any{pair})
 	suite.Require().NoError(err)
-	suite.Equal(0.97, points[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(0.97).String(), points[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(points[pair].Time.Unix(), int64(0))
 
 	// pool['coins'](0), pool['coins'](1)
@@ -169,7 +170,7 @@ func (suite *CurveSuite) TestSuccessResponse() {
 	pair = value.Pair{Base: "STETH", Quote: "ETH"}
 	points, err = suite.origin.FetchDataPoints(context.Background(), []any{pair})
 	suite.Require().NoError(err)
-	suite.Equal(1/0.97, points[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(1/0.97).String(), points[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(points[pair].Time.Unix(), int64(0))
 }
 

--- a/pkg/datapoint/origin/dsr.go
+++ b/pkg/datapoint/origin/dsr.go
@@ -15,7 +15,6 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/ethereum"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log/null"
-	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 const DSRLoggerTag = "DSR_ORIGIN"
@@ -129,11 +128,7 @@ func (d *DSR) FetchDataPoints(ctx context.Context, query []any) (map[any]datapoi
 		avgPrice := new(big.Float).Quo(new(big.Float).SetInt(totals[i]), scaleUp)
 		avgPrice = avgPrice.Quo(avgPrice, new(big.Float).SetUint64(uint64(len(d.blocks))))
 
-		tick := value.Tick{
-			Pair:      pair,
-			Price:     bn.Float(avgPrice),
-			Volume24h: nil,
-		}
+		tick := value.NewTick(pair, avgPrice, nil)
 		points[pair] = datapoint.Point{
 			Value: tick,
 			Time:  time.Now(),

--- a/pkg/datapoint/origin/dsr_test.go
+++ b/pkg/datapoint/origin/dsr_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint/value"
 	ethereumMocks "github.com/chronicleprotocol/oracle-suite/pkg/ethereum/mocks"
+	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 type DSRSuite struct {
@@ -117,7 +118,7 @@ func (suite *DSRSuite) TestSuccessResponse() {
 	pair := value.Pair{Base: "DSR", Quote: "RATE"}
 	points, err := suite.origin.FetchDataPoints(ctx, []any{pair})
 	suite.Require().NoError(err)
-	suite.Equal(1.03, points[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(1.03).String(), points[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(points[pair].Time.Unix(), int64(0))
 }
 

--- a/pkg/datapoint/origin/ishares.go
+++ b/pkg/datapoint/origin/ishares.go
@@ -29,7 +29,6 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint/value"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log/null"
-	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 	"github.com/chronicleprotocol/oracle-suite/pkg/util/webscraper"
 )
 
@@ -112,7 +111,7 @@ func (g *IShares) handle(_ context.Context, pairs []value.Pair, body io.Reader) 
 					ntxt := strings.ReplaceAll(txt, "USD ", "")
 
 					if price, e := strconv.ParseFloat(ntxt, 64); e == nil {
-						tick := value.Tick{Pair: pair, Price: bn.Float(price)}
+						tick := value.NewTick(pair, price, 0)
 						points[pair] = datapoint.Point{
 							Value: tick,
 							Time:  time.Now(),

--- a/pkg/datapoint/origin/ishares_test.go
+++ b/pkg/datapoint/origin/ishares_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint"
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint/value"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log/null"
-	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 func TestIShares_FetchDataPoints(t *testing.T) {
@@ -43,11 +42,8 @@ USD 5.43
 </li></body></html>`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "IBTA", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:  value.Pair{Base: "IBTA", Quote: "USD"},
-						Price: bn.Float(5.43),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "IBTA", Quote: "USD"}, 5.43, 0),
+					Time:  time.Now(),
 				},
 			},
 			skipTimeAssert: true,

--- a/pkg/datapoint/origin/rocketpool.go
+++ b/pkg/datapoint/origin/rocketpool.go
@@ -30,7 +30,6 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/ethereum"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log/null"
-	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 const RocketPoolLoggerTag = "ROCKETPOOL_ORIGIN"
@@ -145,11 +144,7 @@ func (r *RocketPool) FetchDataPoints(ctx context.Context, query []any) (map[any]
 			avgPrice = new(big.Float).Quo(new(big.Float).SetUint64(1), avgPrice)
 		}
 
-		tick := value.Tick{
-			Pair:      pair,
-			Price:     bn.Float(avgPrice),
-			Volume24h: nil,
-		}
+		tick := value.NewTick(pair, avgPrice, nil)
 		points[pair] = datapoint.Point{
 			Value: tick,
 			Time:  time.Now(),

--- a/pkg/datapoint/origin/rocketpool_test.go
+++ b/pkg/datapoint/origin/rocketpool_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint/value"
 	ethereumMocks "github.com/chronicleprotocol/oracle-suite/pkg/ethereum/mocks"
+	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 type RocketPoolSuite struct {
@@ -116,13 +117,13 @@ func (suite *RocketPoolSuite) TestSuccessResponse() {
 	pair := value.Pair{Base: "RETH", Quote: "ETH"}
 	point, err := suite.origin.FetchDataPoints(ctx, []any{pair})
 	suite.Require().NoError(err)
-	suite.Equal(0.97, point[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(0.97).String(), point[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(point[pair].Time.Unix(), int64(0))
 
 	pair = value.Pair{Base: "ETH", Quote: "RETH"}
 	point, err = suite.origin.FetchDataPoints(ctx, []any{pair})
 	suite.Require().NoError(err)
-	suite.Equal(1/0.97, point[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(1/0.97).String(), point[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(point[pair].Time.Unix(), int64(0))
 }
 

--- a/pkg/datapoint/origin/sdai.go
+++ b/pkg/datapoint/origin/sdai.go
@@ -30,7 +30,6 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/ethereum"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log/null"
-	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 const SDAILoggerTag = "SDAI_ORIGIN"
@@ -145,11 +144,7 @@ func (s *SDAI) FetchDataPoints(ctx context.Context, query []any) (map[any]datapo
 			avgPrice = new(big.Float).Quo(new(big.Float).SetUint64(1), avgPrice)
 		}
 
-		tick := value.Tick{
-			Pair:      pair,
-			Price:     bn.Float(avgPrice),
-			Volume24h: nil,
-		}
+		tick := value.NewTick(pair, avgPrice, nil)
 		points[pair] = datapoint.Point{
 			Value: tick,
 			Time:  time.Now(),

--- a/pkg/datapoint/origin/sdai_test.go
+++ b/pkg/datapoint/origin/sdai_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint/value"
 	ethereumMocks "github.com/chronicleprotocol/oracle-suite/pkg/ethereum/mocks"
+	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 type SDAISuite struct {
@@ -116,13 +117,13 @@ func (suite *SDAISuite) TestSuccessResponse() {
 	pair := value.Pair{Base: "SDAI", Quote: "DAI"}
 	points, err := suite.origin.FetchDataPoints(ctx, []any{pair})
 	suite.Require().NoError(err)
-	suite.Equal(1.03, points[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(1.03).String(), points[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(points[pair].Time.Unix(), int64(0))
 
 	pair = value.Pair{Base: "DAI", Quote: "SDAI"}
 	points, err = suite.origin.FetchDataPoints(ctx, []any{pair})
 	suite.Require().NoError(err)
-	suite.Equal(1/1.03, points[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(1/1.03).String(), points[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(points[pair].Time.Unix(), int64(0))
 }
 

--- a/pkg/datapoint/origin/static.go
+++ b/pkg/datapoint/origin/static.go
@@ -23,7 +23,7 @@ func NewStatic() *Static {
 func (s *Static) FetchDataPoints(_ context.Context, query []any) (map[any]datapoint.Point, error) {
 	points := make(map[any]datapoint.Point, len(query))
 	for _, q := range query {
-		f := bn.Float(q)
+		f := bn.DecFloatPoint(q)
 		if f == nil {
 			return nil, fmt.Errorf("invalid query: %T", q)
 		}

--- a/pkg/datapoint/origin/sushiswap.go
+++ b/pkg/datapoint/origin/sushiswap.go
@@ -31,7 +31,6 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/ethereum"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log/null"
-	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 const SushiswapLoggerTag = "SUSHISWAP_ORIGIN"
@@ -248,11 +247,7 @@ func (s *Sushiswap) FetchDataPoints(ctx context.Context, query []any) (map[any]d
 		}
 		avgPrice := new(big.Float).Quo(totals[i], new(big.Float).SetUint64(uint64(len(s.blocks))))
 
-		tick := value.Tick{
-			Pair:      pair,
-			Price:     bn.Float(avgPrice),
-			Volume24h: nil,
-		}
+		tick := value.NewTick(pair, avgPrice, nil)
 		points[pair] = datapoint.Point{
 			Value: tick,
 			Time:  time.Now(),

--- a/pkg/datapoint/origin/tick_generic_http_test.go
+++ b/pkg/datapoint/origin/tick_generic_http_test.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint"
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint/value"
-
-	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 func TestGenericHTTP_FetchDataPoints(t *testing.T) {
@@ -34,24 +32,16 @@ func TestGenericHTTP_FetchDataPoints(t *testing.T) {
 				Callback: func(ctx context.Context, pairs []value.Pair, body io.Reader) (map[any]datapoint.Point, error) {
 					return map[any]datapoint.Point{
 						value.Pair{Base: "BTC", Quote: "USD"}: {
-							Value: value.Tick{
-								Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-								Price:     bn.Float(1000),
-								Volume24h: bn.Float(100),
-							},
-							Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+							Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+							Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 						},
 					}, nil
 				},
 			},
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-						Price:     bn.Float(1000),
-						Volume24h: bn.Float(100),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+					Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 				},
 			},
 			expectedURLs: []string{"/?base=BTC&quote=USD"},
@@ -64,40 +54,24 @@ func TestGenericHTTP_FetchDataPoints(t *testing.T) {
 				Callback: func(ctx context.Context, pairs []value.Pair, body io.Reader) (map[any]datapoint.Point, error) {
 					return map[any]datapoint.Point{
 						value.Pair{Base: "BTC", Quote: "USD"}: {
-							Value: value.Tick{
-								Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-								Price:     bn.Float(1000),
-								Volume24h: bn.Float(100),
-							},
-							Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+							Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+							Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 						},
 						value.Pair{Base: "ETH", Quote: "USD"}: {
-							Value: value.Tick{
-								Pair:      value.Pair{Base: "ETH", Quote: "USD"},
-								Price:     bn.Float(2000),
-								Volume24h: bn.Float(200),
-							},
-							Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+							Value: value.NewTick(value.Pair{Base: "ETH", Quote: "USD"}, 2000, 200),
+							Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 						},
 					}, nil
 				},
 			},
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-						Price:     bn.Float(1000),
-						Volume24h: bn.Float(100),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+					Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 				},
 				value.Pair{Base: "ETH", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "ETH", Quote: "USD"},
-						Price:     bn.Float(2000),
-						Volume24h: bn.Float(200),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+					Value: value.NewTick(value.Pair{Base: "ETH", Quote: "USD"}, 2000, 200),
+					Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 				},
 			},
 			expectedURLs: []string{"/dataPoints"},
@@ -115,23 +89,15 @@ func TestGenericHTTP_FetchDataPoints(t *testing.T) {
 					case "BTC/USD":
 						return map[any]datapoint.Point{
 							value.Pair{Base: "BTC", Quote: "USD"}: {
-								Value: value.Tick{
-									Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-									Price:     bn.Float(1000),
-									Volume24h: bn.Float(100),
-								},
-								Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+								Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+								Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 							},
 						}, nil
 					case "ETH/USD":
 						return map[any]datapoint.Point{
 							value.Pair{Base: "ETH", Quote: "USD"}: {
-								Value: value.Tick{
-									Pair:      value.Pair{Base: "ETC", Quote: "USD"},
-									Price:     bn.Float(2000),
-									Volume24h: bn.Float(200),
-								},
-								Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+								Value: value.NewTick(value.Pair{Base: "ETH", Quote: "USD"}, 2000, 200),
+								Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 							},
 						}, nil
 					}
@@ -140,20 +106,12 @@ func TestGenericHTTP_FetchDataPoints(t *testing.T) {
 			},
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-						Price:     bn.Float(1000),
-						Volume24h: bn.Float(100),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+					Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 				},
 				value.Pair{Base: "ETH", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "ETC", Quote: "USD"},
-						Price:     bn.Float(2000),
-						Volume24h: bn.Float(200),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+					Value: value.NewTick(value.Pair{Base: "ETH", Quote: "USD"}, 2000, 200),
+					Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 				},
 			},
 			expectedURLs: []string{"/?base=BTC&quote=USD", "/?base=ETH&quote=USD"},

--- a/pkg/datapoint/origin/tick_generic_jq.go
+++ b/pkg/datapoint/origin/tick_generic_jq.go
@@ -232,9 +232,9 @@ func (g *TickGenericJQ) handle(
 			for k, v := range v {
 				switch k {
 				case "price":
-					tick.Price = bn.DecFixedPoint(v, value.TickPricePrecision)
+					tick.Price = bn.DecFloatPoint(v)
 				case "volume":
-					tick.Volume24h = bn.DecFixedPoint(v, value.TickVolumePrecision)
+					tick.Volume24h = bn.DecFloatPoint(v)
 				case "time":
 					if tm, ok := anyToTime(v); ok {
 						point.Time = tm
@@ -244,7 +244,7 @@ func (g *TickGenericJQ) handle(
 				}
 			}
 		case int, int32, int64, uint, uint32, uint64, float32, float64:
-			tick.Price = bn.DecFixedPoint(v, value.TickPricePrecision)
+			tick.Price = bn.DecFloatPoint(v)
 		}
 		point.Value = tick
 		points[pair] = point

--- a/pkg/datapoint/origin/tick_generic_jq.go
+++ b/pkg/datapoint/origin/tick_generic_jq.go
@@ -232,9 +232,9 @@ func (g *TickGenericJQ) handle(
 			for k, v := range v {
 				switch k {
 				case "price":
-					tick.Price = bn.Float(v)
+					tick.Price = bn.DecFixedPoint(v, value.TickPricePrecision)
 				case "volume":
-					tick.Volume24h = bn.Float(v)
+					tick.Volume24h = bn.DecFixedPoint(v, value.TickVolumePrecision)
 				case "time":
 					if tm, ok := anyToTime(v); ok {
 						point.Time = tm
@@ -244,7 +244,7 @@ func (g *TickGenericJQ) handle(
 				}
 			}
 		case int, int32, int64, uint, uint32, uint64, float32, float64:
-			tick.Price = bn.Float(v)
+			tick.Price = bn.DecFixedPoint(v, value.TickPricePrecision)
 		}
 		point.Value = tick
 		points[pair] = point

--- a/pkg/datapoint/origin/tick_generic_jq_test.go
+++ b/pkg/datapoint/origin/tick_generic_jq_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint/value"
 
 	"github.com/chronicleprotocol/oracle-suite/pkg/log/null"
-	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 func TestNewGenericJQ(t *testing.T) {
@@ -69,12 +68,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `{"price": "1000", "volume": "100", "time": "2023-05-02T12:34:56Z"}`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-						Price:     bn.Float(1000),
-						Volume24h: bn.Float(100),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+					Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 				},
 			},
 		},
@@ -84,11 +79,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `{"price": "1000", "volume": "100", "time": "2023-05-02T12:34:56Z"}`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:  value.Pair{Base: "BTC", Quote: "USD"},
-						Price: bn.Float(1000),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, nil),
+					Time:  time.Now(),
 				},
 			},
 			skipTimeAssert: true,
@@ -99,11 +91,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `[{"price": "1000"}]`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:  value.Pair{Base: "BTC", Quote: "USD"},
-						Price: bn.Float(1000),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, nil),
+					Time:  time.Now(),
 				},
 			},
 			skipTimeAssert: true,
@@ -114,9 +103,7 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `[{"price": "1000"}, {"price": "2000"}]`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair: value.Pair{Base: "BTC", Quote: "USD"},
-					},
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, nil, nil),
 					Time:  time.Now(),
 					Error: fmt.Errorf("multiple results from JQ query"),
 				},
@@ -129,11 +116,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `[{"price": "1000", "symbol": "BTCUSD"}, {"price": "2000", "symbol": "ETHUSD"}]`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:  value.Pair{Base: "BTC", Quote: "USD"},
-						Price: bn.Float(1000),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, nil),
+					Time:  time.Now(),
 				},
 			},
 			skipTimeAssert: true,
@@ -144,11 +128,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `[{"price": "1000", "symbol": "btcusd"}, {"price": "2000", "symbol": "ethusd"}]`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:  value.Pair{Base: "BTC", Quote: "USD"},
-						Price: bn.Float(1000),
-					},
-					Time: time.Now(),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, nil),
+					Time:  time.Now(),
 				},
 			},
 			skipTimeAssert: true,
@@ -183,12 +164,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `{"price": "1000", "volume": "100", "time": "2023-05-02T12:34:56Z"}`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-						Price:     bn.Float(1000),
-						Volume24h: bn.Float(100),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+					Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 				},
 			},
 		},
@@ -198,12 +175,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `{"price": "1000", "volume": "100", "time": "2023-05-02T12:34:56.123456789Z"}`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-						Price:     bn.Float(1000),
-						Volume24h: bn.Float(100),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 56, 123456789, time.UTC),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+					Time:  time.Date(2023, 5, 2, 12, 34, 56, 123456789, time.UTC),
 				},
 			},
 		},
@@ -213,12 +186,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `{"price": "1000", "volume": "100", "time": "Tue, 02 May 2023 12:34:56 UTC"}`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-						Price:     bn.Float(1000),
-						Volume24h: bn.Float(100),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+					Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 				},
 			},
 		},
@@ -228,12 +197,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `{"price": "1000", "volume": "100", "time": "Tue, 02 May 2023 12:34:56 +0000"}`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-						Price:     bn.Float(1000),
-						Volume24h: bn.Float(100),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.FixedZone("+0000", 0)),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+					Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.FixedZone("+0000", 0)),
 				},
 			},
 		},
@@ -243,12 +208,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `{"price": "1000", "volume": "100", "time": "02 May 23 12:34 UTC"}`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-						Price:     bn.Float(1000),
-						Volume24h: bn.Float(100),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 0, 0, time.UTC),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+					Time:  time.Date(2023, 5, 2, 12, 34, 0, 0, time.UTC),
 				},
 			},
 		},
@@ -258,12 +219,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `{"price": "1000", "volume": "100", "time": "02 May 23 12:34 +0000"}`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-						Price:     bn.Float(1000),
-						Volume24h: bn.Float(100),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 0, 0, time.FixedZone("+0000", 0)),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+					Time:  time.Date(2023, 5, 2, 12, 34, 0, 0, time.FixedZone("+0000", 0)),
 				},
 			},
 		},
@@ -273,12 +230,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `{"price": "1000", "volume": "100", "time": "Tuesday, 02-May-23 12:34:56 UTC"}`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-						Price:     bn.Float(1000),
-						Volume24h: bn.Float(100),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+					Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 				},
 			},
 		},
@@ -288,12 +241,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `{"price": "1000", "volume": "100", "time": "Tue May  2 12:34:56 2023"}`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-						Price:     bn.Float(1000),
-						Volume24h: bn.Float(100),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+					Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 				},
 			},
 		},
@@ -303,12 +252,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `{"price": "1000", "volume": "100", "time": "Tue May  2 12:34:56 UTC 2023"}`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-						Price:     bn.Float(1000),
-						Volume24h: bn.Float(100),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+					Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.UTC),
 				},
 			},
 		},
@@ -318,12 +263,8 @@ func TestGenericJQ_FetchDataPoints(t *testing.T) {
 			responseBody: `{"price": "1000", "volume": "100", "time": "Tue May 02 12:34:56 +0000 2023"}`,
 			expectedResult: map[any]datapoint.Point{
 				value.Pair{Base: "BTC", Quote: "USD"}: {
-					Value: value.Tick{
-						Pair:      value.Pair{Base: "BTC", Quote: "USD"},
-						Price:     bn.Float(1000),
-						Volume24h: bn.Float(100),
-					},
-					Time: time.Date(2023, 5, 2, 12, 34, 56, 0, time.FixedZone("+0000", 0)),
+					Value: value.NewTick(value.Pair{Base: "BTC", Quote: "USD"}, 1000, 100),
+					Time:  time.Date(2023, 5, 2, 12, 34, 56, 0, time.FixedZone("+0000", 0)),
 				},
 			},
 		},

--- a/pkg/datapoint/origin/uniswap_v2_test.go
+++ b/pkg/datapoint/origin/uniswap_v2_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint/value"
 	ethereumMocks "github.com/chronicleprotocol/oracle-suite/pkg/ethereum/mocks"
+	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 type UniswapV2Suite struct {
@@ -163,14 +164,14 @@ func (suite *UniswapV2Suite) TestSuccessResponse() {
 	points, err := suite.origin.FetchDataPoints(context.Background(), []any{pair})
 	suite.Require().NoError(err)
 	const expectedPrice = (200/100.0 + 210/90.0 + 220/80.0) / 3
-	suite.Equal(expectedPrice, points[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(expectedPrice).String(), points[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(points[pair].Time.Unix(), int64(0))
 
 	pair = value.Pair{Base: "WETH", Quote: "STETH"}
 	points, err = suite.origin.FetchDataPoints(context.Background(), []any{pair})
 	suite.Require().NoError(err)
 	const expectedInvertPrice = (100/200.0 + 90/210.0 + 80/220.0) / 3
-	suite.Equal(expectedInvertPrice, points[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(expectedInvertPrice).String(), points[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(points[pair].Time.Unix(), int64(0))
 }
 

--- a/pkg/datapoint/origin/uniswap_v3.go
+++ b/pkg/datapoint/origin/uniswap_v3.go
@@ -31,7 +31,6 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/ethereum"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log/null"
-	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 const UniswapV3LoggerTag = "UNISWAPV3_ORIGIN"
@@ -224,11 +223,7 @@ func (u *UniswapV3) FetchDataPoints(ctx context.Context, query []any) (map[any]d
 
 		avgPrice := new(big.Float).Quo(totals[i], new(big.Float).SetUint64(uint64(len(u.blocks))))
 
-		tick := value.Tick{
-			Pair:      pair,
-			Price:     bn.Float(avgPrice),
-			Volume24h: nil,
-		}
+		tick := value.NewTick(pair, avgPrice, nil)
 		points[pair] = datapoint.Point{
 			Value: tick,
 			Time:  time.Now(),

--- a/pkg/datapoint/origin/wsteth.go
+++ b/pkg/datapoint/origin/wsteth.go
@@ -31,7 +31,6 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/ethereum"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log"
 	"github.com/chronicleprotocol/oracle-suite/pkg/log/null"
-	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 const WrappedStakedETHLoggerTag = "WSTETH_ORIGIN"
@@ -143,11 +142,7 @@ func (w *WrappedStakedETH) FetchDataPoints(ctx context.Context, query []any) (ma
 			avgPrice = new(big.Float).Quo(new(big.Float).SetUint64(1), avgPrice)
 		}
 
-		tick := value.Tick{
-			Pair:      pair,
-			Price:     bn.Float(avgPrice),
-			Volume24h: nil,
-		}
+		tick := value.NewTick(pair, avgPrice, nil)
 		points[pair] = datapoint.Point{
 			Value: tick,
 			Time:  time.Now(),

--- a/pkg/datapoint/origin/wsteth_test.go
+++ b/pkg/datapoint/origin/wsteth_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint/value"
 	ethereumMocks "github.com/chronicleprotocol/oracle-suite/pkg/ethereum/mocks"
+	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
 type WrappedStakedETHSuite struct {
@@ -116,13 +117,13 @@ func (suite *WrappedStakedETHSuite) TestSuccessResponse() {
 	pair := value.Pair{Base: "WSTETH", Quote: "STETH"}
 	points, err := suite.origin.FetchDataPoints(ctx, []any{pair})
 	suite.Require().NoError(err)
-	suite.Equal(0.97, points[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(0.97).String(), points[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(points[pair].Time.Unix(), int64(0))
 
 	pair = value.Pair{Base: "STETH", Quote: "WSTETH"}
 	points, err = suite.origin.FetchDataPoints(ctx, []any{pair})
 	suite.Require().NoError(err)
-	suite.Equal(1/0.97, points[pair].Value.(value.Tick).Price.Float64())
+	suite.Equal(bn.Float(1/0.97).String(), points[pair].Value.(value.Tick).Price.Float().String())
 	suite.Greater(points[pair].Time.Unix(), int64(0))
 }
 

--- a/pkg/datapoint/signer/tick.go
+++ b/pkg/datapoint/signer/tick.go
@@ -92,7 +92,7 @@ func (t *TickRecoverer) Recover(
 func hashTick(model string, price *bn.DecFixedPointNumber, time time.Time) types.Hash {
 	// Price (val):
 	val := make([]byte, 32)
-	price.SetPrecision(contractPricePrecision).RawBigInt().FillBytes(val)
+	price.SetPrec(contractPricePrecision).RawBigInt().FillBytes(val)
 
 	// Time (age):
 	age := make([]byte, 32)

--- a/pkg/datapoint/signer/tick.go
+++ b/pkg/datapoint/signer/tick.go
@@ -89,10 +89,10 @@ func (t *TickRecoverer) Recover(
 }
 
 // hashTick is an equivalent of keccak256(abi.encodePacked(val, age, wat))) in Solidity.
-func hashTick(model string, price *bn.FloatNumber, time time.Time) types.Hash {
+func hashTick(model string, price *bn.DecFixedPointNumber, time time.Time) types.Hash {
 	// Price (val):
 	val := make([]byte, 32)
-	price.DecFixedPoint(contractPricePrecision).RawBigInt().FillBytes(val)
+	price.SetPrecision(contractPricePrecision).RawBigInt().FillBytes(val)
 
 	// Time (age):
 	age := make([]byte, 32)

--- a/pkg/datapoint/signer/tick.go
+++ b/pkg/datapoint/signer/tick.go
@@ -89,10 +89,10 @@ func (t *TickRecoverer) Recover(
 }
 
 // hashTick is an equivalent of keccak256(abi.encodePacked(val, age, wat))) in Solidity.
-func hashTick(model string, price *bn.DecFixedPointNumber, time time.Time) types.Hash {
+func hashTick(model string, price *bn.DecFloatPointNumber, time time.Time) types.Hash {
 	// Price (val):
 	val := make([]byte, 32)
-	price.SetPrec(contractPricePrecision).RawBigInt().FillBytes(val)
+	price.DecFixedPoint(contractPricePrecision).RawBigInt().FillBytes(val)
 
 	// Time (age):
 	age := make([]byte, 32)

--- a/pkg/datapoint/signer/tick_test.go
+++ b/pkg/datapoint/signer/tick_test.go
@@ -56,11 +56,7 @@ func TestTick_Sign(t *testing.T) {
 	k.On("SignMessage", hexutil.MustHexToBytes(priceHash)).Return(expSig, nil).Once()
 
 	retSig, err := s.Sign(context.Background(), "AAABBB", datapoint.Point{
-		Value: value.Tick{
-			Pair:      value.Pair{Base: "AAA", Quote: "BBB"},
-			Price:     bn.Float(42),
-			Volume24h: bn.Float(0),
-		},
+		Value:     value.NewTick(value.Pair{Base: "AAA", Quote: "BBB"}, 42, 0),
 		Time:      time.Unix(1605371361, 0),
 		SubPoints: nil,
 		Meta:      nil,
@@ -80,11 +76,7 @@ func TestTick_Recover(t *testing.T) {
 	r.On("RecoverMessage", hexutil.MustHexToBytes(priceHash), *msgSig).Return(expAddr, nil).Once()
 
 	retAddr, err := s.Recover(context.Background(), "AAABBB", datapoint.Point{
-		Value: value.Tick{
-			Pair:      value.Pair{Base: "AAA", Quote: "BBB"},
-			Price:     bn.Float(42),
-			Volume24h: bn.Float(0),
-		},
+		Value:     value.NewTick(value.Pair{Base: "AAA", Quote: "BBB"}, 42, 0),
 		Time:      time.Unix(1605371361, 0),
 		SubPoints: nil,
 		Meta:      nil,
@@ -96,5 +88,5 @@ func TestTick_Recover(t *testing.T) {
 }
 
 func TestHashTick(t *testing.T) {
-	assert.Equal(t, priceHash, hashTick("AAABBB", bn.Float(42), time.Unix(1605371361, 0)).String())
+	assert.Equal(t, priceHash, hashTick("AAABBB", bn.DecFixedPoint(42, value.TickPricePrecision), time.Unix(1605371361, 0)).String())
 }

--- a/pkg/datapoint/signer/tick_test.go
+++ b/pkg/datapoint/signer/tick_test.go
@@ -88,5 +88,5 @@ func TestTick_Recover(t *testing.T) {
 }
 
 func TestHashTick(t *testing.T) {
-	assert.Equal(t, priceHash, hashTick("AAABBB", bn.DecFixedPoint(42, value.TickPricePrecision), time.Unix(1605371361, 0)).String())
+	assert.Equal(t, priceHash, hashTick("AAABBB", bn.DecFloatPoint(42), time.Unix(1605371361, 0)).String())
 }

--- a/pkg/datapoint/store/store_test.go
+++ b/pkg/datapoint/store/store_test.go
@@ -32,7 +32,7 @@ var (
 	aaabbb1 = &messages.DataPoint{
 		Model: "AAABBB",
 		Point: datapoint.Point{
-			Value: value.StaticValue{Value: bn.Float(1)},
+			Value: value.StaticValue{Value: bn.DecFloatPoint(1)},
 			Time:  time.Unix(1234567890, 0),
 			Meta: map[string]any{
 				"addr": "0x1111111111111111111111111111111111111111",
@@ -43,7 +43,7 @@ var (
 	aaabbb2 = &messages.DataPoint{
 		Model: "AAABBB",
 		Point: datapoint.Point{
-			Value: value.StaticValue{Value: bn.Float(2)},
+			Value: value.StaticValue{Value: bn.DecFloatPoint(2)},
 			Time:  time.Unix(1234567890, 0),
 			Meta: map[string]any{
 				"addr": "0x2222222222222222222222222222222222222222",
@@ -54,7 +54,7 @@ var (
 	xxxyyy1 = &messages.DataPoint{
 		Model: "XXXYYY",
 		Point: datapoint.Point{
-			Value: value.StaticValue{Value: bn.Float(3)},
+			Value: value.StaticValue{Value: bn.DecFloatPoint(3)},
 			Time:  time.Unix(1234567890, 0),
 			Meta: map[string]any{
 				"addr": "0x1111111111111111111111111111111111111111",
@@ -65,7 +65,7 @@ var (
 	xxxyyy2 = &messages.DataPoint{
 		Model: "XXXYYY",
 		Point: datapoint.Point{
-			Value: value.StaticValue{Value: bn.Float(4)},
+			Value: value.StaticValue{Value: bn.DecFloatPoint(4)},
 			Time:  time.Unix(1234567891, 0),
 			Meta: map[string]any{
 				"addr": "0x2222222222222222222222222222222222222222",

--- a/pkg/datapoint/value/static.go
+++ b/pkg/datapoint/value/static.go
@@ -6,22 +6,25 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
-// StaticNumberPrecision is a precision of static numbers.
-const StaticNumberPrecision = 18
-
 // StaticValue is a numeric value obtained from a static origin.
 type StaticValue struct {
-	Value *bn.FloatNumber
+	Value *bn.DecFloatPointNumber
 }
 
 // Number implements the NumericValue interface.
 func (s StaticValue) Number() *bn.FloatNumber {
-	return s.Value
+	if s.Value == nil {
+		return nil
+	}
+	return s.Value.Float()
 }
 
 // Print implements the Value interface.
 func (s StaticValue) Print() string {
-	return s.Value.String()
+	if s.Value == nil {
+		return "<nil>"
+	}
+	return s.Value.Text('g', 10)
 }
 
 func (s StaticValue) MarshalJSON() ([]byte, error) {
@@ -33,6 +36,6 @@ func (s *StaticValue) UnmarshalJSON(bytes []byte) error {
 	if err := json.Unmarshal(bytes, &str); err != nil {
 		return err
 	}
-	s.Value = bn.Float(str)
+	s.Value = bn.DecFloatPoint(str)
 	return nil
 }

--- a/pkg/datapoint/value/tick.go
+++ b/pkg/datapoint/value/tick.go
@@ -23,19 +23,11 @@ import (
 	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
 )
 
-// TickPricePrecision specified number of decimal places for tick prices
-// during marshaling.
-const TickPricePrecision = 18
-
-// TickVolumePrecision specified number of decimal places for tick volumes
-// during marshaling.
-const TickVolumePrecision = 18
-
 func NewTick(pair Pair, price, volume any) Tick {
 	return Tick{
 		Pair:      pair,
-		Price:     bn.DecFixedPoint(price, TickPricePrecision),
-		Volume24h: bn.DecFixedPoint(volume, TickVolumePrecision),
+		Price:     bn.DecFloatPoint(price),
+		Volume24h: bn.DecFloatPoint(volume),
 	}
 }
 
@@ -57,13 +49,13 @@ type Tick struct {
 	// a last trade price, an average of bid and ask prices, etc.
 	//
 	// Price is always non-nil if there is no error.
-	Price *bn.DecFixedPointNumber
+	Price *bn.DecFloatPointNumber
 
 	// Volume24h is a 24h volume for the given asset pair presented in the
 	// base currency.
 	//
 	// May be nil if the provider does not provide volume.
-	Volume24h *bn.DecFixedPointNumber
+	Volume24h *bn.DecFloatPointNumber
 }
 
 // Number implements the NumericValue interface.
@@ -132,8 +124,8 @@ func (t *Tick) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	t.Pair = pair
-	t.Price = bn.DecFixedPoint(result["price"].(string), TickPricePrecision)
-	t.Volume24h = bn.DecFixedPoint(result["volume24h"].(string), TickVolumePrecision)
+	t.Price = bn.DecFloatPoint(result["price"].(string))
+	t.Volume24h = bn.DecFloatPoint(result["volume24h"].(string))
 	return nil
 }
 

--- a/pkg/datapoint/value/tick.go
+++ b/pkg/datapoint/value/tick.go
@@ -36,10 +36,6 @@ func NewTick(pair Pair, price, volume any) Tick {
 //
 // Before using this data, you should check if it is valid by calling
 // Tick.Validate() method.
-//
-// During marshaling, the price and volume are converted to fixed-point
-// numbers with the precision specified by TickPricePrecision and
-// TickVolumePrecision constants.
 type Tick struct {
 	// Pair is an asset pair for which this price is calculated.
 	Pair Pair

--- a/pkg/datapoint/value/tick_test.go
+++ b/pkg/datapoint/value/tick_test.go
@@ -2,7 +2,6 @@ package value
 
 import (
 	"fmt"
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,16 +20,16 @@ func TestTick_Validate(t *testing.T) {
 			name: "valid tick",
 			dataPoint: Tick{
 				Pair:      Pair{Base: "BTC", Quote: "USD"},
-				Price:     bn.Float(1000),
-				Volume24h: bn.Float(100),
+				Price:     bn.DecFixedPoint(1000, TickPricePrecision),
+				Volume24h: bn.DecFixedPoint(100, TickVolumePrecision),
 			},
 			expectError: false,
 		},
 		{
 			name: "pair is not set",
 			dataPoint: Tick{
-				Price:     bn.Float(1000),
-				Volume24h: bn.Float(100),
+				Price:     bn.DecFixedPoint(1000, TickPricePrecision),
+				Volume24h: bn.DecFixedPoint(100, TickVolumePrecision),
 			},
 			expectError:   true,
 			errorContains: "pair is not set",
@@ -39,7 +38,7 @@ func TestTick_Validate(t *testing.T) {
 			name: "price is nil",
 			dataPoint: Tick{
 				Pair:      Pair{Base: "BTC", Quote: "USD"},
-				Volume24h: bn.Float(100),
+				Volume24h: bn.DecFixedPoint(100, TickPricePrecision),
 			},
 			expectError:   true,
 			errorContains: "price is nil",
@@ -48,8 +47,8 @@ func TestTick_Validate(t *testing.T) {
 			name: "price is zero",
 			dataPoint: Tick{
 				Pair:      Pair{Base: "BTC", Quote: "USD"},
-				Price:     bn.Float(0),
-				Volume24h: bn.Float(100),
+				Price:     bn.DecFixedPoint(0, TickPricePrecision),
+				Volume24h: bn.DecFixedPoint(100, TickVolumePrecision),
 			},
 			expectError:   true,
 			errorContains: "price is zero or negative",
@@ -58,28 +57,18 @@ func TestTick_Validate(t *testing.T) {
 			name: "price is negative",
 			dataPoint: Tick{
 				Pair:      Pair{Base: "BTC", Quote: "USD"},
-				Price:     bn.Float(-1000),
-				Volume24h: bn.Float(100),
+				Price:     bn.DecFixedPoint(-1000, TickPricePrecision),
+				Volume24h: bn.DecFixedPoint(100, TickVolumePrecision),
 			},
 			expectError:   true,
 			errorContains: "price is zero or negative",
 		},
 		{
-			name: "price is infinite",
-			dataPoint: Tick{
-				Pair:      Pair{Base: "BTC", Quote: "USD"},
-				Price:     bn.Float(math.Inf(1)),
-				Volume24h: bn.Float(100),
-			},
-			expectError:   true,
-			errorContains: "price is infinite",
-		},
-		{
 			name: "volume is negative",
 			dataPoint: Tick{
 				Pair:      Pair{Base: "BTC", Quote: "USD"},
-				Price:     bn.Float(1000),
-				Volume24h: bn.Float(-100),
+				Price:     bn.DecFixedPoint(1000, TickPricePrecision),
+				Volume24h: bn.DecFixedPoint(-100, TickVolumePrecision),
 			},
 			expectError:   true,
 			errorContains: "volume is negative",

--- a/pkg/datapoint/value/tick_test.go
+++ b/pkg/datapoint/value/tick_test.go
@@ -20,16 +20,16 @@ func TestTick_Validate(t *testing.T) {
 			name: "valid tick",
 			dataPoint: Tick{
 				Pair:      Pair{Base: "BTC", Quote: "USD"},
-				Price:     bn.DecFixedPoint(1000, TickPricePrecision),
-				Volume24h: bn.DecFixedPoint(100, TickVolumePrecision),
+				Price:     bn.DecFloatPoint(1000),
+				Volume24h: bn.DecFloatPoint(100),
 			},
 			expectError: false,
 		},
 		{
 			name: "pair is not set",
 			dataPoint: Tick{
-				Price:     bn.DecFixedPoint(1000, TickPricePrecision),
-				Volume24h: bn.DecFixedPoint(100, TickVolumePrecision),
+				Price:     bn.DecFloatPoint(1000),
+				Volume24h: bn.DecFloatPoint(100),
 			},
 			expectError:   true,
 			errorContains: "pair is not set",
@@ -38,7 +38,7 @@ func TestTick_Validate(t *testing.T) {
 			name: "price is nil",
 			dataPoint: Tick{
 				Pair:      Pair{Base: "BTC", Quote: "USD"},
-				Volume24h: bn.DecFixedPoint(100, TickPricePrecision),
+				Volume24h: bn.DecFloatPoint(100),
 			},
 			expectError:   true,
 			errorContains: "price is nil",
@@ -47,8 +47,8 @@ func TestTick_Validate(t *testing.T) {
 			name: "price is zero",
 			dataPoint: Tick{
 				Pair:      Pair{Base: "BTC", Quote: "USD"},
-				Price:     bn.DecFixedPoint(0, TickPricePrecision),
-				Volume24h: bn.DecFixedPoint(100, TickVolumePrecision),
+				Price:     bn.DecFloatPoint(0),
+				Volume24h: bn.DecFloatPoint(100),
 			},
 			expectError:   true,
 			errorContains: "price is zero or negative",
@@ -57,8 +57,8 @@ func TestTick_Validate(t *testing.T) {
 			name: "price is negative",
 			dataPoint: Tick{
 				Pair:      Pair{Base: "BTC", Quote: "USD"},
-				Price:     bn.DecFixedPoint(-1000, TickPricePrecision),
-				Volume24h: bn.DecFixedPoint(100, TickVolumePrecision),
+				Price:     bn.DecFloatPoint(-1000),
+				Volume24h: bn.DecFloatPoint(100),
 			},
 			expectError:   true,
 			errorContains: "price is zero or negative",
@@ -67,8 +67,8 @@ func TestTick_Validate(t *testing.T) {
 			name: "volume is negative",
 			dataPoint: Tick{
 				Pair:      Pair{Base: "BTC", Quote: "USD"},
-				Price:     bn.DecFixedPoint(1000, TickPricePrecision),
-				Volume24h: bn.DecFixedPoint(-100, TickVolumePrecision),
+				Price:     bn.DecFloatPoint(1000),
+				Volume24h: bn.DecFloatPoint(-100),
 			},
 			expectError:   true,
 			errorContains: "volume is negative",

--- a/pkg/feed/feed_test.go
+++ b/pkg/feed/feed_test.go
@@ -72,7 +72,7 @@ func TestFeed_Broadcast(t *testing.T) {
 			dataModels: []string{"AAABBB"},
 			mocks: func(p *dataMocks.Provider) {
 				point := datapoint.Point{
-					Value: value.StaticValue{Value: bn.Float(42)},
+					Value: value.StaticValue{Value: bn.DecFloatPoint(42)},
 					Time:  time.Unix(100, 0),
 				}
 				p.On("ModelNames", mock.Anything).Return(
@@ -101,7 +101,7 @@ func TestFeed_Broadcast(t *testing.T) {
 			dataModels: []string{"AAABBB", "CCCDDD"},
 			mocks: func(p *dataMocks.Provider) {
 				point := datapoint.Point{
-					Value: value.StaticValue{Value: bn.Float(42)},
+					Value: value.StaticValue{Value: bn.DecFloatPoint(42)},
 					Time:  time.Unix(100, 0),
 				}
 				p.On("ModelNames", mock.Anything).Return(

--- a/pkg/feed/hook.go
+++ b/pkg/feed/hook.go
@@ -1,0 +1,116 @@
+//  Copyright (C) 2021-2023 Chronicle Labs, Inc.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package feed
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint"
+	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint/value"
+)
+
+// TickPrecisionHook is a hook that adjusts the precision of price and volume
+// values in data points that hold a value.Tick.
+type TickPrecisionHook struct {
+	pricePrec  uint8
+	volumePrec uint8
+}
+
+// NewTickPrecisionHook creates a new TickPrecisionHook with the specified
+// price and volume precisions.
+func NewTickPrecisionHook(pricePrec, volumePrec uint8) *TickPrecisionHook {
+	return &TickPrecisionHook{
+		pricePrec:  pricePrec,
+		volumePrec: volumePrec,
+	}
+}
+
+// BeforeSign implements the Hook interface.
+func (t *TickPrecisionHook) BeforeSign(_ context.Context, dp *datapoint.Point) error {
+	*dp = adjustPrec(*dp, t.pricePrec, t.volumePrec)
+	return nil
+}
+
+func adjustPrec(dp datapoint.Point, pricePrec, volumePrec uint8) datapoint.Point {
+	tick, ok := dp.Value.(value.Tick)
+	if !ok {
+		return dp
+	}
+	if tick.Price != nil {
+		tick.Price = tick.Price.SetPrec(pricePrec)
+	}
+	if tick.Volume24h != nil {
+		tick.Volume24h = tick.Volume24h.SetPrec(volumePrec)
+	}
+	dp.Value = tick
+	for i, subPoint := range dp.SubPoints {
+		dp.SubPoints[i] = adjustPrec(subPoint, pricePrec, volumePrec)
+	}
+	return dp
+}
+
+// BeforeBroadcast implements the Hook interface.
+func (t *TickPrecisionHook) BeforeBroadcast(_ context.Context, _ *datapoint.Point) error {
+	return nil
+}
+
+// TickTraceHook is a hook that adds a trace meta field that holds the price of
+// the tick at each origin.
+type TickTraceHook struct{}
+
+// NewTickTraceHook creates a new TickTraceHook instance.
+func NewTickTraceHook() *TickTraceHook {
+	return &TickTraceHook{}
+}
+
+// BeforeSign implements the Hook interface.
+func (t *TickTraceHook) BeforeSign(_ context.Context, _ *datapoint.Point) error {
+	return nil
+}
+
+// BeforeBroadcast implements the Hook interface.
+func (t *TickTraceHook) BeforeBroadcast(_ context.Context, dp *datapoint.Point) error {
+	trace := buildTraceMap(*dp)
+	if len(trace) > 0 {
+		dp.Meta["trace"] = trace
+	}
+	return nil
+}
+
+func buildTraceMap(dp datapoint.Point) map[string]string {
+	trace := make(map[string]string)
+	var recur func(dp datapoint.Point) []datapoint.Point
+	recur = func(dp datapoint.Point) []datapoint.Point {
+		var points []datapoint.Point
+		if dp.Meta["type"] == "origin" {
+			points = append(points, dp)
+		}
+		for _, subPoint := range dp.SubPoints {
+			points = append(points, recur(subPoint)...)
+		}
+		return points
+	}
+
+	for _, point := range recur(dp) {
+		tick, ok := point.Value.(value.Tick)
+		if !ok || point.Meta == nil || tick.Price == nil {
+			continue
+		}
+		trace[fmt.Sprintf("%s@%s", tick.Pair.String(), point.Meta["origin"])] = tick.Price.String()
+	}
+	return trace
+}

--- a/pkg/feed/hook_test.go
+++ b/pkg/feed/hook_test.go
@@ -28,8 +28,8 @@ import (
 
 func TestNewTickPrecisionHook(t *testing.T) {
 	hook := NewTickPrecisionHook(2, 3)
-	assert.Equal(t, uint8(2), hook.pricePrec)
-	assert.Equal(t, uint8(3), hook.volumePrec)
+	assert.Equal(t, uint8(2), hook.maxPricePrec)
+	assert.Equal(t, uint8(3), hook.maxVolumePrec)
 }
 
 func TestTickPrecisionHook_BeforeSign(t *testing.T) {

--- a/pkg/feed/hook_test.go
+++ b/pkg/feed/hook_test.go
@@ -1,0 +1,99 @@
+//  Copyright (C) 2021-2023 Chronicle Labs, Inc.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package feed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint"
+	"github.com/chronicleprotocol/oracle-suite/pkg/datapoint/value"
+	"github.com/chronicleprotocol/oracle-suite/pkg/util/bn"
+)
+
+func TestNewTickPrecisionHook(t *testing.T) {
+	hook := NewTickPrecisionHook(2, 3)
+	assert.Equal(t, uint8(2), hook.pricePrec)
+	assert.Equal(t, uint8(3), hook.volumePrec)
+}
+
+func TestTickPrecisionHook_BeforeSign(t *testing.T) {
+	hook := NewTickPrecisionHook(2, 3)
+	dp := &datapoint.Point{
+		Value: value.Tick{
+			Price:     bn.DecFloatPoint("123.456789"),
+			Volume24h: bn.DecFloatPoint("987.654321"),
+		},
+		SubPoints: []datapoint.Point{
+			{
+				Value: value.Tick{
+					Price:     bn.DecFloatPoint("123.456789"),
+					Volume24h: bn.DecFloatPoint("987.654321"),
+				},
+			},
+		},
+	}
+
+	err := hook.BeforeSign(context.Background(), dp)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "123.46", dp.Value.(value.Tick).Price.String())
+	assert.Equal(t, "987.654", dp.Value.(value.Tick).Volume24h.String())
+	assert.Equal(t, "123.46", dp.SubPoints[0].Value.(value.Tick).Price.String())
+	assert.Equal(t, "987.654", dp.SubPoints[0].Value.(value.Tick).Volume24h.String())
+}
+
+func TestNewTickTraceHook(t *testing.T) {
+	hook := NewTickTraceHook()
+	assert.NotNil(t, hook)
+}
+
+func TestTickTraceHook_BeforeBroadcast(t *testing.T) {
+	hook := NewTickTraceHook()
+	dp := &datapoint.Point{
+		Meta: map[string]any{
+			"type":   "origin",
+			"origin": "source1",
+		},
+		Value: value.Tick{
+			Pair:  value.Pair{Base: "BTC", Quote: "USD"},
+			Price: bn.DecFloatPoint("123.456789"),
+		},
+		SubPoints: []datapoint.Point{
+			{
+				Meta: map[string]any{
+					"type":   "origin",
+					"origin": "source2",
+				},
+				Value: value.Tick{
+					Pair:  value.Pair{Base: "BTC", Quote: "USD"},
+					Price: bn.DecFloatPoint("987.654321"),
+				},
+			},
+		},
+	}
+
+	err := hook.BeforeBroadcast(context.Background(), dp)
+	assert.NoError(t, err)
+
+	expectedTrace := map[string]string{
+		"BTC/USD@source1": "123.456789",
+		"BTC/USD@source2": "987.654321",
+	}
+	assert.Equal(t, expectedTrace, dp.Meta["trace"])
+}

--- a/pkg/relay/median.go
+++ b/pkg/relay/median.go
@@ -214,7 +214,7 @@ func (w *medianWorker) getDataPoints(ctx context.Context, after time.Time, quoru
 func dataPointsToPrices(dataPoints []datapoint.Point) []*bn.DecFixedPointNumber {
 	prices := make([]*bn.DecFixedPointNumber, len(dataPoints))
 	for i, dp := range dataPoints {
-		prices[i] = dp.Value.(value.Tick).Price.SetPrecision(contract.MedianPricePrecision)
+		prices[i] = dp.Value.(value.Tick).Price.SetPrec(contract.MedianPricePrecision)
 	}
 	return prices
 }
@@ -232,7 +232,7 @@ func calculateMedian(prices []*bn.DecFixedPointNumber) *bn.DecFixedPointNumber {
 		m := count / 2
 		a := prices[m-1]
 		b := prices[m]
-		return a.Add(b).Div(2)
+		return a.Add(b).Div(bn.DecFixedPoint(2, 0))
 	}
 	return prices[(count-1)/2]
 }

--- a/pkg/relay/median.go
+++ b/pkg/relay/median.go
@@ -214,7 +214,7 @@ func (w *medianWorker) getDataPoints(ctx context.Context, after time.Time, quoru
 func dataPointsToPrices(dataPoints []datapoint.Point) []*bn.DecFixedPointNumber {
 	prices := make([]*bn.DecFixedPointNumber, len(dataPoints))
 	for i, dp := range dataPoints {
-		prices[i] = dp.Value.(value.Tick).Price.DecFixedPoint(contract.MedianPricePrecision)
+		prices[i] = dp.Value.(value.Tick).Price.SetPrecision(contract.MedianPricePrecision)
 	}
 	return prices
 }

--- a/pkg/relay/median.go
+++ b/pkg/relay/median.go
@@ -88,7 +88,7 @@ func (w *medianWorker) tryUpdate(ctx context.Context) error {
 
 	prices := dataPointsToPrices(dataPoints)
 	median := calculateMedian(prices)
-	spread := calculateSpread(median, val)
+	spread := calculateSpread(median, val.DecFloatPoint())
 
 	// Check if price on the Median contract needs to be updated.
 	// The price needs to be updated if:
@@ -120,7 +120,7 @@ func (w *medianWorker) tryUpdate(ctx context.Context) error {
 		vals := make([]contract.MedianVal, len(prices))
 		for i := range dataPoints {
 			vals[i] = contract.MedianVal{
-				Val: prices[i],
+				Val: prices[i].DecFixedPoint(contract.MedianPricePrecision),
 				Age: dataPoints[i].Time,
 				V:   uint8(signatures[i].V.Uint64()),
 				R:   signatures[i].R,
@@ -211,19 +211,19 @@ func (w *medianWorker) getDataPoints(ctx context.Context, after time.Time, quoru
 }
 
 // dataPointsToPrices extracts prices from data points.
-func dataPointsToPrices(dataPoints []datapoint.Point) []*bn.DecFixedPointNumber {
-	prices := make([]*bn.DecFixedPointNumber, len(dataPoints))
+func dataPointsToPrices(dataPoints []datapoint.Point) []*bn.DecFloatPointNumber {
+	prices := make([]*bn.DecFloatPointNumber, len(dataPoints))
 	for i, dp := range dataPoints {
-		prices[i] = dp.Value.(value.Tick).Price.SetPrec(contract.MedianPricePrecision)
+		prices[i] = dp.Value.(value.Tick).Price
 	}
 	return prices
 }
 
 // calculateMedian calculates the median price.
-func calculateMedian(prices []*bn.DecFixedPointNumber) *bn.DecFixedPointNumber {
+func calculateMedian(prices []*bn.DecFloatPointNumber) *bn.DecFloatPointNumber {
 	count := len(prices)
 	if count == 0 {
-		return bn.DecFixedPoint(0, contract.MedianPricePrecision)
+		return bn.DecFloatPoint(0)
 	}
 	sort.Slice(prices, func(i, j int) bool {
 		return prices[i].Cmp(prices[j]) < 0
@@ -232,7 +232,7 @@ func calculateMedian(prices []*bn.DecFixedPointNumber) *bn.DecFixedPointNumber {
 		m := count / 2
 		a := prices[m-1]
 		b := prices[m]
-		return a.Add(b).Div(bn.DecFixedPoint(2, 0))
+		return a.Add(b).Div(bn.DecFloatPoint(0))
 	}
 	return prices[(count-1)/2]
 }

--- a/pkg/relay/opscribe.go
+++ b/pkg/relay/opscribe.go
@@ -108,7 +108,7 @@ func (w *opScribeWorker) tryUpdate(ctx context.Context) error {
 		//   field.
 		// - Price differs from the current price by more than is specified in the
 		//   OracleSpread field.
-		spread := calculateSpread(pokeData.Val, meta.Val)
+		spread := calculateSpread(pokeData.Val.DecFloatPoint(), meta.Val.DecFloatPoint())
 		isExpired := time.Since(pokeData.Age) >= w.expiration
 		isStale := math.IsInf(spread, 0) || spread >= w.spread
 

--- a/pkg/relay/scribe.go
+++ b/pkg/relay/scribe.go
@@ -99,7 +99,7 @@ func (w *scribeWorker) tryUpdate(ctx context.Context) error {
 		//   field.
 		// - Price differs from the current price by more than is specified in the
 		//   OracleSpread field.
-		spread := calculateSpread(pokeData.Val, meta.Val)
+		spread := calculateSpread(pokeData.Val.DecFloatPoint(), meta.Val.DecFloatPoint())
 		isExpired := time.Since(pokeData.Age) >= w.expiration
 		isStale := math.IsInf(spread, 0) || spread >= w.spread
 

--- a/pkg/relay/util.go
+++ b/pkg/relay/util.go
@@ -35,7 +35,7 @@ func calculateSpread(new, old *bn.DecFixedPointNumber) float64 {
 	if old.Sign() == 0 {
 		return math.Inf(1)
 	}
-	spread, _ := new.Sub(old).Div(old).Mul(bn.Float(100)).Abs().BigFloat().Float64()
+	spread, _ := new.Sub(old).Div(old).Mul(bn.DecFixedPoint(100, 0)).Abs().BigFloat().Float64()
 	return spread
 }
 

--- a/pkg/relay/util.go
+++ b/pkg/relay/util.go
@@ -35,7 +35,8 @@ func calculateSpread(new, old *bn.DecFixedPointNumber) float64 {
 	if old.Sign() == 0 {
 		return math.Inf(1)
 	}
-	return new.Sub(old).Div(old).Mul(bn.Float(100)).Abs().Float64()
+	spread, _ := new.Sub(old).Div(old).Mul(bn.Float(100)).Abs().BigFloat().Float64()
+	return spread
 }
 
 // randomInts generates a slice of integers from 0 to n (exclusive), shuffled

--- a/pkg/relay/util.go
+++ b/pkg/relay/util.go
@@ -31,11 +31,11 @@ import (
 //	abs((new - old) / old * 100)
 //
 // If old is zero, the result is positive infinity.
-func calculateSpread(new, old *bn.DecFixedPointNumber) float64 {
+func calculateSpread(new, old *bn.DecFloatPointNumber) float64 {
 	if old.Sign() == 0 {
 		return math.Inf(1)
 	}
-	spread, _ := new.Sub(old).Div(old).Mul(bn.DecFixedPoint(100, 0)).Abs().BigFloat().Float64()
+	spread, _ := new.Sub(old).Div(old).Mul(bn.DecFloatPoint(100)).Abs().BigFloat().Float64()
 	return spread
 }
 

--- a/pkg/relay/util_test.go
+++ b/pkg/relay/util_test.go
@@ -12,15 +12,15 @@ import (
 func TestCalculateSpread(t *testing.T) {
 	tests := []struct {
 		name     string
-		new, old *bn.DecFixedPointNumber
+		new, old *bn.DecFloatPointNumber
 		expected float64
 	}{
-		{"calculateSpread(150, 100)", bn.DecFixedPoint(150, 18), bn.DecFixedPoint(100, 18), 50},
-		{"calculateSpread(50, 100)", bn.DecFixedPoint(50, 18), bn.DecFixedPoint(100, 18), 50},
-		{"calculateSpread(100, 100)", bn.DecFixedPoint(100, 18), bn.DecFixedPoint(100, 18), 0},
-		{"calculateSpread(100, 0)", bn.DecFixedPoint(100, 18), bn.DecFixedPoint(0, 18), math.Inf(1)},
-		{"calculateSpread(-100, 0)", bn.DecFixedPoint(-100, 18), bn.DecFixedPoint(0, 18), math.Inf(1)},
-		{"calculateSpread(0, 0)", bn.DecFixedPoint(0, 18), bn.DecFixedPoint(0, 18), math.Inf(1)},
+		{"calculateSpread(150, 100)", bn.DecFloatPoint(150), bn.DecFloatPoint(100), 50},
+		{"calculateSpread(50, 100)", bn.DecFloatPoint(50), bn.DecFloatPoint(100), 50},
+		{"calculateSpread(100, 100)", bn.DecFloatPoint(100), bn.DecFloatPoint(100), 0},
+		{"calculateSpread(100, 0)", bn.DecFloatPoint(100), bn.DecFloatPoint(0), math.Inf(1)},
+		{"calculateSpread(-100, 0)", bn.DecFloatPoint(-100), bn.DecFloatPoint(0), math.Inf(1)},
+		{"calculateSpread(0, 0)", bn.DecFloatPoint(0), bn.DecFloatPoint(0), math.Inf(1)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/spire/api_test.go
+++ b/pkg/spire/api_test.go
@@ -44,7 +44,7 @@ var (
 	testPriceAAABBB = &messages.DataPoint{
 		Model: "AAA/BBB",
 		Point: datapoint.Point{
-			Value: value.StaticValue{Value: bn.Float(10.0)},
+			Value: value.StaticValue{Value: bn.DecFloatPoint(10.0)},
 			Time:  time.Unix(1234567890, 0),
 			Meta: map[string]any{
 				"addr": testAddress.String(),

--- a/pkg/transport/messages/datapoint.go
+++ b/pkg/transport/messages/datapoint.go
@@ -167,7 +167,7 @@ func dataPointValueToProtobuf(val value.Value) (*pb.DataPointValue, error) {
 	case value.StaticValue:
 		var static []byte
 		if typ.Value != nil {
-			static, err = decFixedPointToBytes(typ.Value.DecFixedPoint(value.StaticNumberPrecision))
+			static, err = decFloatPointToBytes(typ.Value)
 			if err != nil {
 				return nil, err
 			}
@@ -181,13 +181,13 @@ func dataPointValueToProtobuf(val value.Value) (*pb.DataPointValue, error) {
 			volume24H []byte
 		)
 		if typ.Price != nil {
-			price, err = decFixedPointToBytes(typ.Price.DecFixedPoint(value.TickPricePrecision))
+			price, err = decFixedPointToBytes(typ.Price)
 			if err != nil {
 				return nil, err
 			}
 		}
 		if typ.Volume24h != nil {
-			volume24H, err = decFixedPointToBytes(typ.Volume24h.DecFixedPoint(value.TickVolumePrecision))
+			volume24H, err = decFixedPointToBytes(typ.Volume24h)
 			if err != nil {
 				return nil, err
 			}
@@ -211,11 +211,11 @@ func dataPointValueFromProtobuf(msg *pb.DataPointValue) (value.Value, error) {
 	case *pb.DataPointValue_Static:
 		val := value.StaticValue{}
 		if typ.Static != nil {
-			static, err := bytesToDecFixedPoint(typ.Static)
+			static, err := bytesToDecFloatPoint(typ.Static)
 			if err != nil {
 				return nil, err
 			}
-			val.Value = static.Float()
+			val.Value = static
 		}
 		return val, nil
 	case *pb.DataPointValue_Tick:
@@ -230,14 +230,14 @@ func dataPointValueFromProtobuf(msg *pb.DataPointValue) (value.Value, error) {
 			if err != nil {
 				return nil, err
 			}
-			val.Price = price.Float()
+			val.Price = price
 		}
 		if typ.Tick.Volume24H != nil {
 			volume24H, err := bytesToDecFixedPoint(typ.Tick.Volume24H)
 			if err != nil {
 				return nil, err
 			}
-			val.Volume24h = volume24H.Float()
+			val.Volume24h = volume24H
 		}
 		return val, nil
 	}

--- a/pkg/transport/messages/datapoint.go
+++ b/pkg/transport/messages/datapoint.go
@@ -181,13 +181,13 @@ func dataPointValueToProtobuf(val value.Value) (*pb.DataPointValue, error) {
 			volume24H []byte
 		)
 		if typ.Price != nil {
-			price, err = decFixedPointToBytes(typ.Price)
+			price, err = decFloatPointToBytes(typ.Price)
 			if err != nil {
 				return nil, err
 			}
 		}
 		if typ.Volume24h != nil {
-			volume24H, err = decFixedPointToBytes(typ.Volume24h)
+			volume24H, err = decFloatPointToBytes(typ.Volume24h)
 			if err != nil {
 				return nil, err
 			}
@@ -226,14 +226,14 @@ func dataPointValueFromProtobuf(msg *pb.DataPointValue) (value.Value, error) {
 		}
 		val.Pair = pair
 		if typ.Tick.Price != nil {
-			price, err := bytesToDecFixedPoint(typ.Tick.Price)
+			price, err := bytesToDecFloatPoint(typ.Tick.Price)
 			if err != nil {
 				return nil, err
 			}
 			val.Price = price
 		}
 		if typ.Tick.Volume24H != nil {
-			volume24H, err := bytesToDecFixedPoint(typ.Tick.Volume24H)
+			volume24H, err := bytesToDecFloatPoint(typ.Tick.Volume24H)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/transport/messages/messages.go
+++ b/pkg/transport/messages/messages.go
@@ -63,6 +63,18 @@ func appInfoFromProtobuf(a *pb.AppInfo) transport.AppInfo {
 	}
 }
 
+func decFloatPointToBytes(d *bn.DecFloatPointNumber) ([]byte, error) {
+	return d.MarshalBinary()
+}
+
+func bytesToDecFloatPoint(b []byte) (*bn.DecFloatPointNumber, error) {
+	d := new(bn.DecFloatPointNumber)
+	if err := d.UnmarshalBinary(b); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
 func decFixedPointToBytes(d *bn.DecFixedPointNumber) ([]byte, error) {
 	return d.MarshalBinary()
 }

--- a/pkg/util/bn/bn.go
+++ b/pkg/util/bn/bn.go
@@ -26,9 +26,9 @@ import (
 const MaxDecPointPrecision = math.MaxUint8
 
 const (
-	// divGuardDigits is the number of decimal digits to use as guard digits
-	// when dividing two DecFixedPointNumber / DecFloatPointNumber.
-	divGuardDigits = 2
+	// decGuardDigits is the number of decimal digits to use as guard digits
+	// when performing arithmetic operations that may result in rounding.
+	decGuardDigits = 2
 
 	// divPrecisionIncrease is the number of decimal digits to increase when
 	// dividing two DecFloatPointNumber.

--- a/pkg/util/bn/bn.go
+++ b/pkg/util/bn/bn.go
@@ -1,59 +1,169 @@
+//  Copyright (C) 2021-2023 Chronicle Labs, Inc.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package bn
 
 import (
+	"math"
 	"math/big"
+	"strings"
+
+	"golang.org/x/exp/constraints"
 )
 
 var (
-	intOne   = big.NewInt(1)
-	intTen   = big.NewInt(10)
-	floatOne = big.NewFloat(1)
+	intZero   = big.NewInt(0)
+	intOne    = big.NewInt(1)
+	intTen    = big.NewInt(10)
+	floatHalf = big.NewFloat(0.5)
+	floatOne  = big.NewFloat(1)
 )
 
+func convertIntToDecFloatPoint(x *IntNumber) *DecFloatPointNumber {
+	return &DecFloatPointNumber{x: convertIntToDecFixedPoint(x, 0)}
+}
+
+func convertFloatToDecFloatPoint(x *FloatNumber) *DecFloatPointNumber {
+	prec := floatDecimalPrecision(x)
+	if prec < 0 {
+		return nil
+	}
+	if prec > math.MaxUint8 {
+		prec = math.MaxUint8
+	}
+	return &DecFloatPointNumber{x: convertFloatToDecFixedPoint(x, uint8(prec))}
+}
+
+func convertDecFixedPointToDecFloatPoint(x *DecFixedPointNumber) *DecFloatPointNumber {
+	return &DecFloatPointNumber{x: x}
+}
+
+func convertBigIntToDecFloatPoint(x *big.Int) *DecFloatPointNumber {
+	return &DecFloatPointNumber{x: convertBigIntToDecFixedPoint(x, 0)}
+}
+
+func convertBigFloatToDecFloatPoint(x *big.Float) *DecFloatPointNumber {
+	if x == nil || x.IsInf() {
+		return nil
+	}
+	prec := bigFloatDecimalPrecision(x)
+	if prec < 0 {
+		return nil
+	}
+	if prec > math.MaxUint8 {
+		prec = math.MaxUint8
+	}
+	return &DecFloatPointNumber{x: convertBigFloatToDecFixedPoint(x, uint8(prec))}
+}
+
+func convertInt64ToDecFloatPoint(x int64) *DecFloatPointNumber {
+	return &DecFloatPointNumber{x: convertInt64ToDecFixedPoint(x, 0)}
+}
+
+func convertUint64ToDecFloatPoint(x uint64) *DecFloatPointNumber {
+	return &DecFloatPointNumber{x: convertUint64ToDecFixedPoint(x, 0)}
+}
+
+func convertFloat64ToDecFloatPoint(x float64) *DecFloatPointNumber {
+	if math.IsInf(x, 0) || math.IsNaN(x) {
+		return nil
+	}
+	prec := float64DecimalPrecision(x)
+	if prec < 0 {
+		return nil
+	}
+	if prec > math.MaxUint8 {
+		prec = math.MaxUint8
+	}
+	fixed := convertFloat64ToDecFixedPoint(x, uint8(prec))
+	if fixed == nil {
+		return nil
+	}
+	return &DecFloatPointNumber{x: fixed}
+}
+
+func convertStringToDecFloatPoint(x string) *DecFloatPointNumber {
+	prec := stringNumberDecimalPrecision(x)
+	if prec < 0 {
+		return nil
+	}
+	if prec > math.MaxUint8 {
+		prec = math.MaxUint8
+	}
+	fixed := convertStringToDecFixedPoint(x, uint8(prec))
+	if fixed == nil {
+		return nil
+	}
+	return &DecFloatPointNumber{x: fixed}
+}
+
 func convertIntToDecFixedPoint(x *IntNumber, n uint8) *DecFixedPointNumber {
-	return &DecFixedPointNumber{x: x.Mul(decFixedPointScale(n)).BigInt(), n: n}
+	return &DecFixedPointNumber{x: x.Mul(pow10(n)).BigInt(), prec: n}
 }
 
 func convertFloatToDecFixedPoint(x *FloatNumber, n uint8) *DecFixedPointNumber {
-	i, _ := new(big.Float).Mul(x.BigFloat(), new(big.Float).SetInt(decFixedPointScale(n))).Int(nil)
-	return &DecFixedPointNumber{x: i, n: n}
+	i := bigFloatToBigInt(new(big.Float).Mul(x.BigFloat(), new(big.Float).SetInt(pow10(n))))
+	return &DecFixedPointNumber{x: i, prec: n}
+}
+
+func convertDecFloatPointToDecFixedPoint(x *DecFloatPointNumber, n uint8) *DecFixedPointNumber {
+	return x.x.SetPrecision(n)
 }
 
 func convertBigIntToDecFixedPoint(x *big.Int, n uint8) *DecFixedPointNumber {
-	return &DecFixedPointNumber{x: new(big.Int).Mul(x, decFixedPointScale(n)), n: n}
+	return &DecFixedPointNumber{x: new(big.Int).Mul(x, pow10(n)), prec: n}
 }
 
 func convertBigFloatToDecFixedPoint(x *big.Float, n uint8) *DecFixedPointNumber {
-	i, _ := new(big.Float).Mul(x, new(big.Float).SetInt(decFixedPointScale(n))).Int(nil)
-	return &DecFixedPointNumber{x: i, n: n}
+	i := bigFloatToBigInt(new(big.Float).Mul(x, new(big.Float).SetInt(pow10(n))))
+	return &DecFixedPointNumber{x: i, prec: n}
 }
 
 func convertInt64ToDecFixedPoint(x int64, n uint8) *DecFixedPointNumber {
-	return &DecFixedPointNumber{x: new(big.Int).Mul(new(big.Int).SetInt64(x), decFixedPointScale(n)), n: n}
+	return &DecFixedPointNumber{x: new(big.Int).Mul(new(big.Int).SetInt64(x), pow10(n)), prec: n}
 }
 
 func convertUint64ToDecFixedPoint(x uint64, n uint8) *DecFixedPointNumber {
-	return &DecFixedPointNumber{x: new(big.Int).Mul(new(big.Int).SetUint64(x), decFixedPointScale(n)), n: n}
+	return &DecFixedPointNumber{x: new(big.Int).Mul(new(big.Int).SetUint64(x), pow10(n)), prec: n}
 }
 
 func convertFloat64ToDecFixedPoint(x float64, n uint8) *DecFixedPointNumber {
-	i, _ := new(big.Float).Mul(big.NewFloat(x), new(big.Float).SetInt(decFixedPointScale(n))).Int(nil)
-	return &DecFixedPointNumber{x: i, n: n}
+	if math.IsInf(x, 0) || math.IsNaN(x) {
+		return nil
+	}
+	i := bigFloatToBigInt(new(big.Float).Mul(big.NewFloat(x), new(big.Float).SetInt(pow10(n))))
+	return &DecFixedPointNumber{x: i, prec: n}
 }
 
 func convertStringToDecFixedPoint(x string, n uint8) *DecFixedPointNumber {
 	if f, ok := new(big.Float).SetString(x); ok {
-		i, _ := new(big.Float).Mul(f, new(big.Float).SetInt(decFixedPointScale(n))).Int(nil)
-		return &DecFixedPointNumber{x: i, n: n}
+		i := bigFloatToBigInt(new(big.Float).Mul(f, new(big.Float).SetInt(pow10(n))))
+		return &DecFixedPointNumber{x: i, prec: n}
 	}
 	return nil
 }
 
-func convertIntNumberToFloat(x *IntNumber) *FloatNumber {
+func convertIntToFloat(x *IntNumber) *FloatNumber {
 	return &FloatNumber{x: x.BigFloat()}
 }
 
 func convertDecFixedPointToFloat(x *DecFixedPointNumber) *FloatNumber {
+	return &FloatNumber{x: x.BigFloat()}
+}
+
+func convertDecFloatPointToFloat(x *DecFloatPointNumber) *FloatNumber {
 	return &FloatNumber{x: x.BigFloat()}
 }
 
@@ -84,11 +194,15 @@ func convertStringToFloat(x string) *FloatNumber {
 	return nil
 }
 
-func convertFloatNumberToInt(x *FloatNumber) *IntNumber {
+func convertFloatToInt(x *FloatNumber) *IntNumber {
 	return &IntNumber{x: x.BigInt()}
 }
 
 func convertDecFixedPointToInt(x *DecFixedPointNumber) *IntNumber {
+	return &IntNumber{x: x.BigInt()}
+}
+
+func convertDecFloatPointToInt(x *DecFloatPointNumber) *IntNumber {
 	return &IntNumber{x: x.BigInt()}
 }
 
@@ -97,8 +211,7 @@ func convertBigIntToInt(x *big.Int) *IntNumber {
 }
 
 func convertBigFloatToInt(x *big.Float) *IntNumber {
-	i, _ := x.Int(nil)
-	return &IntNumber{x: i}
+	return &IntNumber{x: bigFloatToBigInt(x)}
 }
 
 func convertInt64ToInt(x int64) *IntNumber {
@@ -110,8 +223,7 @@ func convertUint64ToInt(x uint64) *IntNumber {
 }
 
 func convertFloat64ToInt(x float64) *IntNumber {
-	f, _ := big.NewFloat(x).Int(nil)
-	return &IntNumber{x: f}
+	return &IntNumber{x: bigFloatToBigInt(big.NewFloat(x))}
 }
 
 func convertStringToInt(x string) *IntNumber {
@@ -123,10 +235,6 @@ func convertStringToInt(x string) *IntNumber {
 
 func convertBytesToInt(x []byte) *IntNumber {
 	return &IntNumber{x: new(big.Int).SetBytes(x)}
-}
-
-func decFixedPointScale(n uint8) *big.Int {
-	return new(big.Int).Exp(intTen, big.NewInt(int64(n)), nil)
 }
 
 func anyToInt64(x any) int64 {
@@ -169,4 +277,54 @@ func anyToFloat64(x any) float64 {
 		return x
 	}
 	return 0
+}
+
+func floatDecimalPrecision(x *FloatNumber) int {
+	return stringNumberDecimalPrecision(x.Text('f', -1))
+}
+
+func bigFloatDecimalPrecision(x *big.Float) int {
+	return stringNumberDecimalPrecision(x.Text('f', -1))
+}
+
+func float64DecimalPrecision(x float64) int {
+	return stringNumberDecimalPrecision(big.NewFloat(x).Text('f', -1))
+}
+
+func stringNumberDecimalPrecision(x string) int {
+	if f, ok := new(big.Float).SetString(x); ok {
+		s := f.Text('f', -1)
+		if len(s) == 0 {
+			return 0
+		}
+		d := strings.Index(s, ".")
+		if d == -1 {
+			return 0
+		}
+		z := len(s) - 1
+		for z >= d && s[z] == '0' {
+			z--
+		}
+		return z - d
+	}
+	if _, ok := new(big.Int).SetString(x, 0); ok {
+		return 0
+	}
+	return -1
+}
+
+func bigFloatToBigInt(x *big.Float) *big.Int {
+	i, acc := x.Int(nil)
+	if acc == big.Exact {
+		return i
+	}
+	f := x.Sub(x, new(big.Float).SetInt(i))
+	if f.Cmp(floatHalf) >= 0 {
+		i.Add(i, big.NewInt(1))
+	}
+	return i
+}
+
+func pow10[T constraints.Integer](n T) *big.Int {
+	return new(big.Int).Exp(intTen, big.NewInt(int64(n)), nil)
 }

--- a/pkg/util/bn/bn.go
+++ b/pkg/util/bn/bn.go
@@ -27,7 +27,7 @@ var (
 	intZero   = big.NewInt(0)
 	intOne    = big.NewInt(1)
 	intTen    = big.NewInt(10)
-	floatHalf = big.NewFloat(0.5)
+	floatHalf = big.NewFloat(0.5) //nolint:gomnd
 	floatOne  = big.NewFloat(1)
 )
 

--- a/pkg/util/bn/bn_test.go
+++ b/pkg/util/bn/bn_test.go
@@ -1,0 +1,43 @@
+//  Copyright (C) 2021-2023 Chronicle Labs, Inc.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package bn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_countFractionalDigits(t *testing.T) {
+	tests := []struct {
+		num  string
+		want int
+	}{
+		{"0", 0},
+		{"1", 0},
+		{"0.0", 0},
+		{"0.1", 1},
+		{"0.01", 2},
+		{"0.001", 3},
+		{"1.001", 3},
+		{"1.0010", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.num, func(t *testing.T) {
+			assert.Equal(t, tt.want, stringNumberDecimalPrecision(tt.num))
+		})
+	}
+}

--- a/pkg/util/bn/bn_test.go
+++ b/pkg/util/bn/bn_test.go
@@ -37,7 +37,7 @@ func Test_countFractionalDigits(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.num, func(t *testing.T) {
-			p, ok := stringNumberDecimalPrecision(tt.num)
+			p, ok := stringNumberDecPrec(tt.num)
 			assert.Equal(t, uint32(tt.want), p)
 			assert.True(t, ok)
 		})

--- a/pkg/util/bn/bn_test.go
+++ b/pkg/util/bn/bn_test.go
@@ -37,7 +37,9 @@ func Test_countFractionalDigits(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.num, func(t *testing.T) {
-			assert.Equal(t, tt.want, stringNumberDecimalPrecision(tt.num))
+			p, ok := stringNumberDecimalPrecision(tt.num)
+			assert.Equal(t, uint32(tt.want), p)
+			assert.True(t, ok)
 		})
 	}
 }

--- a/pkg/util/bn/decfixedpoint.go
+++ b/pkg/util/bn/decfixedpoint.go
@@ -196,9 +196,6 @@ func (x *DecFixedPointNumber) Sign() int {
 // Before the addition, the precision of x and y is increased to the larger of
 // the two precisions. The precision of the result is set back to the precision
 // of x.
-//
-// The result may be rounded if the precision of x is smaller than the sum of
-// the precisions of x and y.
 func (x *DecFixedPointNumber) Add(y *DecFixedPointNumber) *DecFixedPointNumber {
 	p := max(x.p, y.p)
 	xi := bigIntSetPrec(x.x, uint32(x.p), uint32(p))
@@ -226,10 +223,10 @@ func (x *DecFixedPointNumber) Sub(y *DecFixedPointNumber) *DecFixedPointNumber {
 // sum of the precisions of x and y. The precision of the result is set back to
 // the precision of x.
 func (x *DecFixedPointNumber) Mul(y *DecFixedPointNumber) *DecFixedPointNumber {
-	p := x.p + y.p
-	xi := bigIntSetPrec(x.x, uint32(x.p), uint32(p))
-	yi := bigIntSetPrec(y.x, uint32(y.p), uint32(p))
-	z := bigIntSetPrec(new(big.Int).Mul(xi, yi), uint32(p)*2, uint32(x.p))
+	p := uint32(x.p) + uint32(y.p)
+	xi := bigIntSetPrec(x.x, uint32(x.p), p)
+	yi := bigIntSetPrec(y.x, uint32(y.p), p)
+	z := bigIntSetPrec(new(big.Int).Mul(xi, yi), p*2, uint32(x.p))
 	return &DecFixedPointNumber{x: z, p: x.p}
 }
 
@@ -288,7 +285,7 @@ func (x *DecFixedPointNumber) Inv() *DecFixedPointNumber {
 	if x.x.Sign() == 0 {
 		panic("division by zero")
 	}
-	return &DecFixedPointNumber{x: bigIntDivRound(pow10(x.p*2), x.x), p: x.p}
+	return &DecFixedPointNumber{x: bigIntDivRound(pow10(uint32(x.p)*2), x.x), p: x.p}
 }
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface.

--- a/pkg/util/bn/decfixedpoint.go
+++ b/pkg/util/bn/decfixedpoint.go
@@ -235,12 +235,12 @@ func (x *DecFixedPointNumber) Mul(y *DecFixedPointNumber) *DecFixedPointNumber {
 // Division by zero panics.
 //
 // Before the division, the precision of x and y is increased to the precision
-// of the larger of the two values plus divGuardDigits. The precision of the
+// of the larger of the two values plus decGuardDigits. The precision of the
 // result is set back to the precision of x.
 //
 // To use a different precision, use DivPrec.
 func (x *DecFixedPointNumber) Div(y *DecFixedPointNumber) *DecFixedPointNumber {
-	return x.DivPrec(y, uint32(max(x.p, y.p))+divGuardDigits)
+	return x.DivPrec(y, uint32(max(x.p, y.p))+decGuardDigits)
 }
 
 // DivPrec divides the number by y and returns the result.

--- a/pkg/util/bn/decfixedpoint_test.go
+++ b/pkg/util/bn/decfixedpoint_test.go
@@ -1,6 +1,22 @@
+//  Copyright (C) 2021-2023 Chronicle Labs, Inc.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package bn
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -18,55 +34,86 @@ func TestDecFixedPoint(t *testing.T) {
 			name:     "IntNumber",
 			input:    IntNumber{big.NewInt(42)},
 			prec:     0,
-			expected: &DecFixedPointNumber{x: big.NewInt(42), n: 0},
+			expected: &DecFixedPointNumber{x: big.NewInt(42), prec: 0},
 		},
 		{
-			name:     "pointer to IntNumber",
+			name:     "*IntNumber",
 			input:    &IntNumber{big.NewInt(42)},
 			prec:     0,
-			expected: &DecFixedPointNumber{x: big.NewInt(42), n: 0},
+			expected: &DecFixedPointNumber{x: big.NewInt(42), prec: 0},
 		},
 		{
 			name:     "FloatNumber",
 			input:    FloatNumber{big.NewFloat(42.5)},
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(4250), n: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
 		},
 		{
-			name:     "pointer to FloatNumber",
+			name:     "*FloatNumber",
 			input:    &FloatNumber{big.NewFloat(42.5)},
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(4250), n: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+		},
+		{
+			name:     "DecFixedPointNumber",
+			input:    DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			prec:     2,
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+		},
+		{
+			name:     "*DecFixedPointNumber",
+			input:    &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			prec:     2,
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+		},
+		{
+			name:     "DecFloatPointNumber",
+			input:    DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+			prec:     2,
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+		},
+		{
+			name:     "*DecFloatPointNumber",
+			input:    &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+			prec:     2,
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
 		},
 		{
 			name:     "big.Int",
 			input:    big.NewInt(42),
 			prec:     0,
-			expected: &DecFixedPointNumber{x: big.NewInt(42), n: 0},
+			expected: &DecFixedPointNumber{x: big.NewInt(42), prec: 0},
 		},
 		{
 			name:     "big.Float",
 			input:    big.NewFloat(42.5),
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(4250), n: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
 		},
 		{
 			name:     "int",
 			input:    int(42),
 			prec:     0,
-			expected: &DecFixedPointNumber{x: big.NewInt(42), n: 0},
+			expected: &DecFixedPointNumber{x: big.NewInt(42), prec: 0},
 		},
 		{
 			name:     "float64",
 			input:    float64(42.5),
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(4250), n: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
 		},
 		{
 			name:     "string",
 			input:    "42.5",
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(4250), n: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+		},
+
+		{
+			name:     "big.Float",
+			input:    big.NewFloat(1.03),
+			prec:     2,
+			expected: &DecFixedPointNumber{x: big.NewInt(103), prec: 2},
 		},
 	}
 
@@ -91,47 +138,47 @@ func TestDecFixedPointNumber_String(t *testing.T) {
 	}{
 		{
 			name:     "zero precision",
-			n:        &DecFixedPointNumber{x: big.NewInt(10625), n: 0}, // 10625
+			n:        &DecFixedPointNumber{x: big.NewInt(10625), prec: 0}, // 10625
 			expected: "10625",
 		},
 		{
 			name:     "two digits precision",
-			n:        &DecFixedPointNumber{x: big.NewInt(10625), n: 2}, // 106.25
+			n:        &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}, // 106.25
 			expected: "106.25",
 		},
 		{
 			name:     "ten digits precision",
-			n:        &DecFixedPointNumber{x: big.NewInt(10625), n: 10}, // 0.0000010625
+			n:        &DecFixedPointNumber{x: big.NewInt(10625), prec: 10}, // 0.0000010625
 			expected: "0.0000010625",
 		},
 		{
 			name:     "zero precision negative",
-			n:        &DecFixedPointNumber{x: big.NewInt(-10625), n: 0}, // -10625
+			n:        &DecFixedPointNumber{x: big.NewInt(-10625), prec: 0}, // -10625
 			expected: "-10625",
 		},
 		{
 			name:     "two digits precision negative",
-			n:        &DecFixedPointNumber{x: big.NewInt(-10625), n: 2}, // -106.25
+			n:        &DecFixedPointNumber{x: big.NewInt(-10625), prec: 2}, // -106.25
 			expected: "-106.25",
 		},
 		{
 			name:     "ten digits precision negative",
-			n:        &DecFixedPointNumber{x: big.NewInt(-10625), n: 10}, // -0.0000010625
+			n:        &DecFixedPointNumber{x: big.NewInt(-10625), prec: 10}, // -0.0000010625
 			expected: "-0.0000010625",
 		},
 		{
 			name:     "remove trailing zeros",
-			n:        &DecFixedPointNumber{x: big.NewInt(1062500), n: 4}, // 106.2500
+			n:        &DecFixedPointNumber{x: big.NewInt(1062500), prec: 4}, // 106.2500
 			expected: "106.25",
 		},
 		{
 			name:     "remove trailing zeros (no fractional part)",
-			n:        &DecFixedPointNumber{x: big.NewInt(1060000), n: 4}, // 106
+			n:        &DecFixedPointNumber{x: big.NewInt(1060000), prec: 4}, // 106
 			expected: "106",
 		},
 		{
 			name:     "remove trailing zeros (no integer part)",
-			n:        &DecFixedPointNumber{x: big.NewInt(1062500), n: 10}, // 0.00010625
+			n:        &DecFixedPointNumber{x: big.NewInt(1062500), prec: 10}, // 0.00010625
 			expected: "0.00010625",
 		},
 	}
@@ -152,21 +199,39 @@ func TestDecFixedPointNumber_Add(t *testing.T) {
 	}{
 		{
 			name:     "same precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(1050), n: 2}, // 10.50
-			n2:       &DecFixedPointNumber{x: big.NewInt(225), n: 2},  // 2.25
-			expected: "12.75",
+			n1:       &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}, // 10.50
+			n2:       &DecFixedPointNumber{x: big.NewInt(225), prec: 2},  // 2.25
+			expected: "12.75",                                            // 10.50 + 2.25 = 12.75
 		},
 		{
 			name:     "first higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10500), n: 3}, // 10.500
-			n2:       &DecFixedPointNumber{x: big.NewInt(225), n: 2},   // 2.25
-			expected: "12.75",
+			n1:       &DecFixedPointNumber{x: big.NewInt(10500), prec: 3}, // 10.500
+			n2:       &DecFixedPointNumber{x: big.NewInt(225), prec: 2},   // 2.25
+			expected: "12.75",                                             // 10.500 + 2.25 = 12.75
 		},
 		{
 			name:     "second higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(1050), n: 2}, // 10.50
-			n2:       &DecFixedPointNumber{x: big.NewInt(2250), n: 3}, // 2.250
-			expected: "12.75",
+			n1:       &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}, // 10.50
+			n2:       &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}, // 2.250
+			expected: "12.75",                                            // 10.50 + 2.250 = 12.75
+		},
+		{
+			name:     "maximum precision",
+			n1:       DecFixedPoint(10.50, math.MaxUint8), // 10.50
+			n2:       DecFixedPoint(2.25, math.MaxUint8),  // 2.25
+			expected: "12.75",                             // 10.50 + 2.25 = 12.75
+		},
+		{
+			name:     "zero and maximum precision",
+			n1:       DecFixedPoint(10.50, 0),            // 11.00
+			n2:       DecFixedPoint(2.25, math.MaxUint8), // 2.25
+			expected: "13",                               // 11.00 + 2.25 = 13.25 -> 13
+		},
+		{
+			name:     "maximum and zero precision",
+			n1:       DecFixedPoint(10.50, math.MaxUint8), // 10.50
+			n2:       DecFixedPoint(2.25, 0),              // 2.00
+			expected: "12.5",                              // 10.50 + 2.00 = 12.5
 		},
 	}
 
@@ -187,21 +252,39 @@ func TestDecFixedPointNumber_Sub(t *testing.T) {
 	}{
 		{
 			name:     "same precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(1050), n: 2}, // 10.50
-			n2:       &DecFixedPointNumber{x: big.NewInt(225), n: 2},  // 2.25
-			expected: "8.25",
+			n1:       &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}, // 10.50
+			n2:       &DecFixedPointNumber{x: big.NewInt(225), prec: 2},  // 2.25
+			expected: "8.25",                                             // 10.50 - 2.25 = 8.25
 		},
 		{
 			name:     "first higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10500), n: 3}, // 10.500
-			n2:       &DecFixedPointNumber{x: big.NewInt(225), n: 2},   // 2.25
-			expected: "8.25",
+			n1:       &DecFixedPointNumber{x: big.NewInt(10500), prec: 3}, // 10.500
+			n2:       &DecFixedPointNumber{x: big.NewInt(225), prec: 2},   // 2.25
+			expected: "8.25",                                              // 10.500 - 2.25 = 8.25
 		},
 		{
 			name:     "second higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(1050), n: 2}, // 10.50
-			n2:       &DecFixedPointNumber{x: big.NewInt(2250), n: 3}, // 2.250
-			expected: "8.25",
+			n1:       &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}, // 10.50
+			n2:       &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}, // 2.250
+			expected: "8.25",                                             // 10.50 - 2.250 = 8.25
+		},
+		{
+			name:     "maximum precision",
+			n1:       DecFixedPoint(10.50, math.MaxUint8), // 10.50
+			n2:       DecFixedPoint(2.25, math.MaxUint8),  // 2.25
+			expected: "8.25",                              // 10.50 - 2.25 = 8.25
+		},
+		{
+			name:     "zero and maximum precision",
+			n1:       DecFixedPoint(10.50, 0),            // 11.00
+			n2:       DecFixedPoint(2.25, math.MaxUint8), // 2.25
+			expected: "9",                                // 11.00 - 2.25 = 8.75 -> 9
+		},
+		{
+			name:     "maximum and zero precision",
+			n1:       DecFixedPoint(10.50, math.MaxUint8), // 10.50
+			n2:       DecFixedPoint(2.25, 0),              // 2.00
+			expected: "8.5",                               // 10.50 - 2.00 = 8.50
 		},
 	}
 
@@ -222,21 +305,39 @@ func TestDecFixedPointNumber_Mul(t *testing.T) {
 	}{
 		{
 			name:     "same precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(1050), n: 2}, // 10.50
-			n2:       &DecFixedPointNumber{x: big.NewInt(225), n: 2},  // 2.25
-			expected: "23.62",
+			n1:       &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}, // 10.50
+			n2:       &DecFixedPointNumber{x: big.NewInt(225), prec: 2},  // 2.25
+			expected: "23.62",                                            // 10.50 * 2.25 = 23.625 -> 23.62
 		},
 		{
 			name:     "first higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10500), n: 3}, // 10.500
-			n2:       &DecFixedPointNumber{x: big.NewInt(225), n: 2},   // 2.25
-			expected: "23.625",
+			n1:       &DecFixedPointNumber{x: big.NewInt(10500), prec: 3}, // 10.500
+			n2:       &DecFixedPointNumber{x: big.NewInt(225), prec: 2},   // 2.25
+			expected: "23.625",                                            // 10.500 * 2.25 = 23.625
 		},
 		{
 			name:     "second higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(1050), n: 2}, // 10.50
-			n2:       &DecFixedPointNumber{x: big.NewInt(2250), n: 3}, // 2.250
-			expected: "23.62",
+			n1:       &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}, // 10.50
+			n2:       &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}, // 2.250
+			expected: "23.62",                                            // 10.50 * 2.250 = 23.625 -> 23.62
+		},
+		{
+			name:     "maximum precision",
+			n1:       DecFixedPoint("10.5", math.MaxUint8), // 10.50
+			n2:       DecFixedPoint("2.25", math.MaxUint8), // 2.25
+			expected: "23.625",                             // 10.50 * 2.25 = 23.625
+		},
+		{
+			name:     "zero and maximum precision",
+			n1:       DecFixedPoint("10.5", 0),             // 11.00
+			n2:       DecFixedPoint("2.25", math.MaxUint8), // 2.00
+			expected: "22",                                 // 11.00 * 2.00 = 22.00
+		},
+		{
+			name:     "maximum and zero precision",
+			n1:       DecFixedPoint("10.5", math.MaxUint8), // 10.50
+			n2:       DecFixedPoint("2.25", 0),             // 2.00
+			expected: "21",                                 // 10.50 * 2.00 = 21.00
 		},
 	}
 
@@ -257,21 +358,39 @@ func TestDecFixedPointNumber_Div(t *testing.T) {
 	}{
 		{
 			name:     "same precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10625), n: 2}, // 106.25
-			n2:       &DecFixedPointNumber{x: big.NewInt(425), n: 2},   // 4.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}, // 106.25
+			n2:       &DecFixedPointNumber{x: big.NewInt(425), prec: 2},   // 4.25
 			expected: "25",
 		},
 		{
 			name:     "first higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(106250), n: 3}, // 106.250
-			n2:       &DecFixedPointNumber{x: big.NewInt(425), n: 2},    // 4.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(106250), prec: 3}, // 106.250
+			n2:       &DecFixedPointNumber{x: big.NewInt(425), prec: 2},    // 4.25
 			expected: "25",
 		},
 		{
 			name:     "second higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10625), n: 2}, // 106.25
-			n2:       &DecFixedPointNumber{x: big.NewInt(4250), n: 3},  // 4.250
+			n1:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}, // 106.25
+			n2:       &DecFixedPointNumber{x: big.NewInt(4250), prec: 3},  // 4.250
 			expected: "25",
+		},
+		{
+			name:     "maximum precision",
+			n1:       DecFixedPoint("106.25", math.MaxUint8), // 106.25
+			n2:       DecFixedPoint("4.25", math.MaxUint8),   // 4.25
+			expected: "25",
+		},
+		{
+			name:     "zero and maximum precision",
+			n1:       DecFixedPoint("106.25", 0),           // 106.00
+			n2:       DecFixedPoint("4.25", math.MaxUint8), // 4.00 (precision of first number is 0)
+			expected: "26",                                 // 106.00 / 4.00 = 26.50 -> 26
+		},
+		{
+			name:     "maximum and zero precision",
+			n1:       DecFixedPoint("106.25", math.MaxUint8), // 106.25
+			n2:       DecFixedPoint("4.25", 0),               // 4.00
+			expected: "26.5625",                              // 106.25 / 4.00 = 26.5625
 		},
 	}
 
@@ -292,32 +411,32 @@ func TestDecFixedPointNumber_Cmp(t *testing.T) {
 	}{
 		{
 			name:     "same precision equal",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10625), n: 2}, // 106.25
-			n2:       &DecFixedPointNumber{x: big.NewInt(10625), n: 2}, // 106.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}, // 106.25
+			n2:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}, // 106.25
 			expected: 0,
 		},
 		{
 			name:     "same precision less than",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10625), n: 2}, // 106.25
-			n2:       &DecFixedPointNumber{x: big.NewInt(20625), n: 2}, // 206.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}, // 106.25
+			n2:       &DecFixedPointNumber{x: big.NewInt(20625), prec: 2}, // 206.25
 			expected: -1,
 		},
 		{
 			name:     "same precision greater than",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10625), n: 2}, // 106.25
-			n2:       &DecFixedPointNumber{x: big.NewInt(625), n: 2},   // 6.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}, // 106.25
+			n2:       &DecFixedPointNumber{x: big.NewInt(625), prec: 2},   // 6.25
 			expected: 1,
 		},
 		{
 			name:     "first higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(106250), n: 3}, // 106.250
-			n2:       &DecFixedPointNumber{x: big.NewInt(10625), n: 2},  // 106.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(106250), prec: 3}, // 106.250
+			n2:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2},  // 106.25
 			expected: 0,
 		},
 		{
 			name:     "second higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10625), n: 2},  // 106.25
-			n2:       &DecFixedPointNumber{x: big.NewInt(106250), n: 3}, // 106.250
+			n1:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2},  // 106.25
+			n2:       &DecFixedPointNumber{x: big.NewInt(106250), prec: 3}, // 106.250
 			expected: 0,
 		},
 	}
@@ -331,25 +450,51 @@ func TestDecFixedPointNumber_Cmp(t *testing.T) {
 }
 
 func TestDecFixedPointNumber_Abs(t *testing.T) {
-	number := &DecFixedPointNumber{x: big.NewInt(-10625), n: 2} // -106.25
+	number := &DecFixedPointNumber{x: big.NewInt(-10625), prec: 2} // -106.25
 
-	expectedAbs := &DecFixedPointNumber{x: big.NewInt(10625), n: 2} // 106.25
+	expectedAbs := &DecFixedPointNumber{x: big.NewInt(10625), prec: 2} // 106.25
 	resultAbs := number.Abs()
 	assert.Equal(t, expectedAbs.x, resultAbs.x)
-	assert.Equal(t, expectedAbs.n, resultAbs.n)
+	assert.Equal(t, expectedAbs.prec, resultAbs.prec)
 }
 
 func TestDecFixedPointNumber_Neg(t *testing.T) {
-	number := &DecFixedPointNumber{x: big.NewInt(10625), n: 2} // 106.25
+	number := &DecFixedPointNumber{x: big.NewInt(10625), prec: 2} // 106.25
 
-	expectedNeg := &DecFixedPointNumber{x: big.NewInt(-10625), n: 2} // -106.25
+	expectedNeg := &DecFixedPointNumber{x: big.NewInt(-10625), prec: 2} // -106.25
 	resultNeg := number.Neg()
 	assert.Equal(t, expectedNeg.x, resultNeg.x)
-	assert.Equal(t, expectedNeg.n, resultNeg.n)
+	assert.Equal(t, expectedNeg.prec, resultNeg.prec)
+}
+
+func TestDecFixedPointNumber_Inv(t *testing.T) {
+	tests := []struct {
+		name     string
+		number   *DecFixedPointNumber
+		expected string
+	}{
+		{
+			name:     "0-digits",
+			number:   &DecFixedPointNumber{x: big.NewInt(106), prec: 0},
+			expected: "0",
+		},
+		{
+			name:     "6-digits",
+			number:   &DecFixedPointNumber{x: big.NewInt(106250000), prec: 6},
+			expected: "0.009411",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.number.Inv()
+			assert.Equal(t, tt.expected, result.String())
+		})
+	}
 }
 
 func TestDecFixedPointNumber_MarshalBinary(t *testing.T) {
-	number := &DecFixedPointNumber{x: big.NewInt(10625), n: 2} // 106.25
+	number := &DecFixedPointNumber{x: big.NewInt(10625), prec: 2} // 106.25
 
 	data, err := number.MarshalBinary()
 	assert.NoError(t, err)
@@ -365,6 +510,6 @@ func TestDecFixedPointNumber_UnmarshalBinary(t *testing.T) {
 	err := number.UnmarshalBinary(data)
 	assert.NoError(t, err)
 
-	expectedNumber := &DecFixedPointNumber{x: big.NewInt(10625), n: 2}
+	expectedNumber := &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}
 	assert.Equal(t, expectedNumber, number)
 }

--- a/pkg/util/bn/decfixedpoint_test.go
+++ b/pkg/util/bn/decfixedpoint_test.go
@@ -181,6 +181,11 @@ func TestDecFixedPointNumber_String(t *testing.T) {
 			n:        &DecFixedPointNumber{x: big.NewInt(1062500), p: 10}, // 0.00010625
 			expected: "0.00010625",
 		},
+		{
+			name:     "large precision",
+			n:        &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision},
+			expected: "1",
+		},
 	}
 
 	for _, tt := range tests {
@@ -232,6 +237,12 @@ func TestDecFixedPointNumber_Add(t *testing.T) {
 			n1:       DecFixedPoint(10.50, MaxDecPointPrecision), // 10.50
 			n2:       DecFixedPoint(2.25, 0),                     // 2.00
 			expected: "12.5",                                     // 10.50 + 2.00 = 12.5
+		},
+		{
+			name:     "large precision",
+			n1:       &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision},
+			n2:       &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision},
+			expected: "2",
 		},
 	}
 
@@ -286,6 +297,12 @@ func TestDecFixedPointNumber_Sub(t *testing.T) {
 			n2:       DecFixedPoint(2.25, 0),                     // 2.00
 			expected: "8.5",                                      // 10.50 - 2.00 = 8.50
 		},
+		{
+			name:     "large precision",
+			n1:       &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision},
+			n2:       &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision},
+			expected: "0",
+		},
 	}
 
 	for _, tt := range tests {
@@ -338,6 +355,12 @@ func TestDecFixedPointNumber_Mul(t *testing.T) {
 			n1:       DecFixedPoint("10.5", MaxDecPointPrecision), // 10.50
 			n2:       DecFixedPoint("2.25", 0),                    // 2.00
 			expected: "21",                                        // 10.50 * 2.00 = 21.00
+		},
+		{
+			name:     "large precision",
+			n1:       &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision},
+			n2:       &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision},
+			expected: "1",
 		},
 	}
 
@@ -404,6 +427,12 @@ func TestDecFixedPointNumber_Div(t *testing.T) {
 			n2:       DecFixedPoint("1.5", 1), // 1.5
 			expected: "0.7",                   // 1.0 / 1.5 = 0.66 -> 0.7
 		},
+		{
+			name:     "large precision",
+			n1:       &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision},
+			n2:       &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision},
+			expected: "1",
+		},
 	}
 
 	for _, tt := range tests {
@@ -451,6 +480,12 @@ func TestDecFixedPointNumber_Cmp(t *testing.T) {
 			n2:       &DecFixedPointNumber{x: big.NewInt(106250), p: 3}, // 106.250
 			expected: 0,
 		},
+		{
+			name:     "large precision",
+			n1:       &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision},
+			n2:       &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision},
+			expected: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -482,29 +517,29 @@ func TestDecFixedPointNumber_Neg(t *testing.T) {
 func TestDecFixedPointNumber_Inv(t *testing.T) {
 	tests := []struct {
 		name     string
-		number   *DecFixedPointNumber
+		n        *DecFixedPointNumber
 		expected string
 	}{
 		{
 			name:     "0-digits",
-			number:   &DecFixedPointNumber{x: big.NewInt(106), p: 0},
+			n:        &DecFixedPointNumber{x: big.NewInt(106), p: 0},
 			expected: "0",
 		},
 		{
 			name:     "6-digits",
-			number:   &DecFixedPointNumber{x: big.NewInt(106250000), p: 6},
+			n:        &DecFixedPointNumber{x: big.NewInt(106250000), p: 6},
 			expected: "0.009412",
 		},
 		{
 			name:     "large precision",
-			number:   &DecFixedPointNumber{x: new(big.Int).Add(pow10(255), big.NewInt(1)), p: 255},
+			n:        &DecFixedPointNumber{x: new(big.Int).Add(pow10(MaxDecPointPrecision), big.NewInt(1)), p: MaxDecPointPrecision},
 			expected: "0." + strings.Repeat("9", 255),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.number.Inv()
+			result := tt.n.Inv()
 			assert.Equal(t, tt.expected, result.String())
 		})
 	}

--- a/pkg/util/bn/decfixedpoint_test.go
+++ b/pkg/util/bn/decfixedpoint_test.go
@@ -17,6 +17,7 @@ package bn
 
 import (
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -493,6 +494,11 @@ func TestDecFixedPointNumber_Inv(t *testing.T) {
 			name:     "6-digits",
 			number:   &DecFixedPointNumber{x: big.NewInt(106250000), p: 6},
 			expected: "0.009412",
+		},
+		{
+			name:     "large precision",
+			number:   &DecFixedPointNumber{x: new(big.Int).Add(pow10(255), big.NewInt(1)), p: 255},
+			expected: "0." + strings.Repeat("9", 255),
 		},
 	}
 

--- a/pkg/util/bn/decfixedpoint_test.go
+++ b/pkg/util/bn/decfixedpoint_test.go
@@ -16,7 +16,6 @@
 package bn
 
 import (
-	"math"
 	"math/big"
 	"testing"
 
@@ -34,86 +33,86 @@ func TestDecFixedPoint(t *testing.T) {
 			name:     "IntNumber",
 			input:    IntNumber{big.NewInt(42)},
 			prec:     0,
-			expected: &DecFixedPointNumber{x: big.NewInt(42), prec: 0},
+			expected: &DecFixedPointNumber{x: big.NewInt(42), p: 0},
 		},
 		{
 			name:     "*IntNumber",
 			input:    &IntNumber{big.NewInt(42)},
 			prec:     0,
-			expected: &DecFixedPointNumber{x: big.NewInt(42), prec: 0},
+			expected: &DecFixedPointNumber{x: big.NewInt(42), p: 0},
 		},
 		{
 			name:     "FloatNumber",
 			input:    FloatNumber{big.NewFloat(42.5)},
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 		},
 		{
 			name:     "*FloatNumber",
 			input:    &FloatNumber{big.NewFloat(42.5)},
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 		},
 		{
 			name:     "DecFixedPointNumber",
-			input:    DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			input:    DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 		},
 		{
 			name:     "*DecFixedPointNumber",
-			input:    &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			input:    &DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 		},
 		{
 			name:     "DecFloatPointNumber",
-			input:    DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+			input:    DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), p: 2}},
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 		},
 		{
 			name:     "*DecFloatPointNumber",
-			input:    &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+			input:    &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), p: 2}},
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 		},
 		{
 			name:     "big.Int",
 			input:    big.NewInt(42),
 			prec:     0,
-			expected: &DecFixedPointNumber{x: big.NewInt(42), prec: 0},
+			expected: &DecFixedPointNumber{x: big.NewInt(42), p: 0},
 		},
 		{
 			name:     "big.Float",
 			input:    big.NewFloat(42.5),
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 		},
 		{
 			name:     "int",
 			input:    int(42),
 			prec:     0,
-			expected: &DecFixedPointNumber{x: big.NewInt(42), prec: 0},
+			expected: &DecFixedPointNumber{x: big.NewInt(42), p: 0},
 		},
 		{
 			name:     "float64",
 			input:    float64(42.5),
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 		},
 		{
 			name:     "string",
 			input:    "42.5",
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 		},
 
 		{
 			name:     "big.Float",
 			input:    big.NewFloat(1.03),
 			prec:     2,
-			expected: &DecFixedPointNumber{x: big.NewInt(103), prec: 2},
+			expected: &DecFixedPointNumber{x: big.NewInt(103), p: 2},
 		},
 	}
 
@@ -124,7 +123,7 @@ func TestDecFixedPoint(t *testing.T) {
 				assert.Nil(t, result)
 			} else {
 				assert.Equal(t, test.expected.String(), result.String())
-				assert.Equal(t, test.expected.Precision(), result.Precision())
+				assert.Equal(t, test.expected.Prec(), result.Prec())
 			}
 		})
 	}
@@ -138,47 +137,47 @@ func TestDecFixedPointNumber_String(t *testing.T) {
 	}{
 		{
 			name:     "zero precision",
-			n:        &DecFixedPointNumber{x: big.NewInt(10625), prec: 0}, // 10625
+			n:        &DecFixedPointNumber{x: big.NewInt(10625), p: 0}, // 10625
 			expected: "10625",
 		},
 		{
 			name:     "two digits precision",
-			n:        &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}, // 106.25
+			n:        &DecFixedPointNumber{x: big.NewInt(10625), p: 2}, // 106.25
 			expected: "106.25",
 		},
 		{
 			name:     "ten digits precision",
-			n:        &DecFixedPointNumber{x: big.NewInt(10625), prec: 10}, // 0.0000010625
+			n:        &DecFixedPointNumber{x: big.NewInt(10625), p: 10}, // 0.0000010625
 			expected: "0.0000010625",
 		},
 		{
 			name:     "zero precision negative",
-			n:        &DecFixedPointNumber{x: big.NewInt(-10625), prec: 0}, // -10625
+			n:        &DecFixedPointNumber{x: big.NewInt(-10625), p: 0}, // -10625
 			expected: "-10625",
 		},
 		{
 			name:     "two digits precision negative",
-			n:        &DecFixedPointNumber{x: big.NewInt(-10625), prec: 2}, // -106.25
+			n:        &DecFixedPointNumber{x: big.NewInt(-10625), p: 2}, // -106.25
 			expected: "-106.25",
 		},
 		{
 			name:     "ten digits precision negative",
-			n:        &DecFixedPointNumber{x: big.NewInt(-10625), prec: 10}, // -0.0000010625
+			n:        &DecFixedPointNumber{x: big.NewInt(-10625), p: 10}, // -0.0000010625
 			expected: "-0.0000010625",
 		},
 		{
 			name:     "remove trailing zeros",
-			n:        &DecFixedPointNumber{x: big.NewInt(1062500), prec: 4}, // 106.2500
+			n:        &DecFixedPointNumber{x: big.NewInt(1062500), p: 4}, // 106.2500
 			expected: "106.25",
 		},
 		{
 			name:     "remove trailing zeros (no fractional part)",
-			n:        &DecFixedPointNumber{x: big.NewInt(1060000), prec: 4}, // 106
+			n:        &DecFixedPointNumber{x: big.NewInt(1060000), p: 4}, // 106
 			expected: "106",
 		},
 		{
 			name:     "remove trailing zeros (no integer part)",
-			n:        &DecFixedPointNumber{x: big.NewInt(1062500), prec: 10}, // 0.00010625
+			n:        &DecFixedPointNumber{x: big.NewInt(1062500), p: 10}, // 0.00010625
 			expected: "0.00010625",
 		},
 	}
@@ -199,39 +198,39 @@ func TestDecFixedPointNumber_Add(t *testing.T) {
 	}{
 		{
 			name:     "same precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}, // 10.50
-			n2:       &DecFixedPointNumber{x: big.NewInt(225), prec: 2},  // 2.25
-			expected: "12.75",                                            // 10.50 + 2.25 = 12.75
+			n1:       &DecFixedPointNumber{x: big.NewInt(1050), p: 2}, // 10.50
+			n2:       &DecFixedPointNumber{x: big.NewInt(225), p: 2},  // 2.25
+			expected: "12.75",                                         // 10.50 + 2.25 = 12.75
 		},
 		{
 			name:     "first higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10500), prec: 3}, // 10.500
-			n2:       &DecFixedPointNumber{x: big.NewInt(225), prec: 2},   // 2.25
-			expected: "12.75",                                             // 10.500 + 2.25 = 12.75
+			n1:       &DecFixedPointNumber{x: big.NewInt(10500), p: 3}, // 10.500
+			n2:       &DecFixedPointNumber{x: big.NewInt(225), p: 2},   // 2.25
+			expected: "12.75",                                          // 10.500 + 2.25 = 12.75
 		},
 		{
 			name:     "second higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}, // 10.50
-			n2:       &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}, // 2.250
-			expected: "12.75",                                            // 10.50 + 2.250 = 12.75
+			n1:       &DecFixedPointNumber{x: big.NewInt(1050), p: 2}, // 10.50
+			n2:       &DecFixedPointNumber{x: big.NewInt(2250), p: 3}, // 2.250
+			expected: "12.75",                                         // 10.50 + 2.250 = 12.75
 		},
 		{
 			name:     "maximum precision",
-			n1:       DecFixedPoint(10.50, math.MaxUint8), // 10.50
-			n2:       DecFixedPoint(2.25, math.MaxUint8),  // 2.25
-			expected: "12.75",                             // 10.50 + 2.25 = 12.75
+			n1:       DecFixedPoint(10.50, MaxDecPointPrecision), // 10.50
+			n2:       DecFixedPoint(2.25, MaxDecPointPrecision),  // 2.25
+			expected: "12.75",                                    // 10.50 + 2.25 = 12.75
 		},
 		{
 			name:     "zero and maximum precision",
-			n1:       DecFixedPoint(10.50, 0),            // 11.00
-			n2:       DecFixedPoint(2.25, math.MaxUint8), // 2.25
-			expected: "13",                               // 11.00 + 2.25 = 13.25 -> 13
+			n1:       DecFixedPoint(10.50, 0),                   // 11.00
+			n2:       DecFixedPoint(2.25, MaxDecPointPrecision), // 2.25
+			expected: "13",                                      // 11.00 + 2.25 = 13.25 -> 13
 		},
 		{
 			name:     "maximum and zero precision",
-			n1:       DecFixedPoint(10.50, math.MaxUint8), // 10.50
-			n2:       DecFixedPoint(2.25, 0),              // 2.00
-			expected: "12.5",                              // 10.50 + 2.00 = 12.5
+			n1:       DecFixedPoint(10.50, MaxDecPointPrecision), // 10.50
+			n2:       DecFixedPoint(2.25, 0),                     // 2.00
+			expected: "12.5",                                     // 10.50 + 2.00 = 12.5
 		},
 	}
 
@@ -252,39 +251,39 @@ func TestDecFixedPointNumber_Sub(t *testing.T) {
 	}{
 		{
 			name:     "same precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}, // 10.50
-			n2:       &DecFixedPointNumber{x: big.NewInt(225), prec: 2},  // 2.25
-			expected: "8.25",                                             // 10.50 - 2.25 = 8.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(1050), p: 2}, // 10.50
+			n2:       &DecFixedPointNumber{x: big.NewInt(225), p: 2},  // 2.25
+			expected: "8.25",                                          // 10.50 - 2.25 = 8.25
 		},
 		{
 			name:     "first higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10500), prec: 3}, // 10.500
-			n2:       &DecFixedPointNumber{x: big.NewInt(225), prec: 2},   // 2.25
-			expected: "8.25",                                              // 10.500 - 2.25 = 8.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(10500), p: 3}, // 10.500
+			n2:       &DecFixedPointNumber{x: big.NewInt(225), p: 2},   // 2.25
+			expected: "8.25",                                           // 10.500 - 2.25 = 8.25
 		},
 		{
 			name:     "second higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}, // 10.50
-			n2:       &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}, // 2.250
-			expected: "8.25",                                             // 10.50 - 2.250 = 8.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(1050), p: 2}, // 10.50
+			n2:       &DecFixedPointNumber{x: big.NewInt(2250), p: 3}, // 2.250
+			expected: "8.25",                                          // 10.50 - 2.250 = 8.25
 		},
 		{
 			name:     "maximum precision",
-			n1:       DecFixedPoint(10.50, math.MaxUint8), // 10.50
-			n2:       DecFixedPoint(2.25, math.MaxUint8),  // 2.25
-			expected: "8.25",                              // 10.50 - 2.25 = 8.25
+			n1:       DecFixedPoint(10.50, MaxDecPointPrecision), // 10.50
+			n2:       DecFixedPoint(2.25, MaxDecPointPrecision),  // 2.25
+			expected: "8.25",                                     // 10.50 - 2.25 = 8.25
 		},
 		{
 			name:     "zero and maximum precision",
-			n1:       DecFixedPoint(10.50, 0),            // 11.00
-			n2:       DecFixedPoint(2.25, math.MaxUint8), // 2.25
-			expected: "9",                                // 11.00 - 2.25 = 8.75 -> 9
+			n1:       DecFixedPoint(10.50, 0),                   // 11.00
+			n2:       DecFixedPoint(2.25, MaxDecPointPrecision), // 2.25
+			expected: "9",                                       // 11.00 - 2.25 = 8.75 -> 9
 		},
 		{
 			name:     "maximum and zero precision",
-			n1:       DecFixedPoint(10.50, math.MaxUint8), // 10.50
-			n2:       DecFixedPoint(2.25, 0),              // 2.00
-			expected: "8.5",                               // 10.50 - 2.00 = 8.50
+			n1:       DecFixedPoint(10.50, MaxDecPointPrecision), // 10.50
+			n2:       DecFixedPoint(2.25, 0),                     // 2.00
+			expected: "8.5",                                      // 10.50 - 2.00 = 8.50
 		},
 	}
 
@@ -305,39 +304,39 @@ func TestDecFixedPointNumber_Mul(t *testing.T) {
 	}{
 		{
 			name:     "same precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}, // 10.50
-			n2:       &DecFixedPointNumber{x: big.NewInt(225), prec: 2},  // 2.25
-			expected: "23.62",                                            // 10.50 * 2.25 = 23.625 -> 23.62
+			n1:       &DecFixedPointNumber{x: big.NewInt(1050), p: 2}, // 10.50
+			n2:       &DecFixedPointNumber{x: big.NewInt(225), p: 2},  // 2.25
+			expected: "23.63",                                         // 10.50 * 2.25 = 23.625 -> 23.62
 		},
 		{
 			name:     "first higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10500), prec: 3}, // 10.500
-			n2:       &DecFixedPointNumber{x: big.NewInt(225), prec: 2},   // 2.25
-			expected: "23.625",                                            // 10.500 * 2.25 = 23.625
+			n1:       &DecFixedPointNumber{x: big.NewInt(10500), p: 3}, // 10.500
+			n2:       &DecFixedPointNumber{x: big.NewInt(225), p: 2},   // 2.25
+			expected: "23.625",                                         // 10.500 * 2.25 = 23.625
 		},
 		{
 			name:     "second higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}, // 10.50
-			n2:       &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}, // 2.250
-			expected: "23.62",                                            // 10.50 * 2.250 = 23.625 -> 23.62
+			n1:       &DecFixedPointNumber{x: big.NewInt(1050), p: 2}, // 10.50
+			n2:       &DecFixedPointNumber{x: big.NewInt(2250), p: 3}, // 2.250
+			expected: "23.63",                                         // 10.50 * 2.250 = 23.625 -> 23.63
 		},
 		{
 			name:     "maximum precision",
-			n1:       DecFixedPoint("10.5", math.MaxUint8), // 10.50
-			n2:       DecFixedPoint("2.25", math.MaxUint8), // 2.25
-			expected: "23.625",                             // 10.50 * 2.25 = 23.625
+			n1:       DecFixedPoint("10.5", MaxDecPointPrecision), // 10.50
+			n2:       DecFixedPoint("2.25", MaxDecPointPrecision), // 2.25
+			expected: "23.625",                                    // 10.50 * 2.25 = 23.625
 		},
 		{
 			name:     "zero and maximum precision",
-			n1:       DecFixedPoint("10.5", 0),             // 11.00
-			n2:       DecFixedPoint("2.25", math.MaxUint8), // 2.00
-			expected: "22",                                 // 11.00 * 2.00 = 22.00
+			n1:       DecFixedPoint("10.5", 0),                    // 11.00
+			n2:       DecFixedPoint("2.25", MaxDecPointPrecision), // 2.25
+			expected: "25",                                        // 11.00 * 2.25 = 24.75 -> 25
 		},
 		{
 			name:     "maximum and zero precision",
-			n1:       DecFixedPoint("10.5", math.MaxUint8), // 10.50
-			n2:       DecFixedPoint("2.25", 0),             // 2.00
-			expected: "21",                                 // 10.50 * 2.00 = 21.00
+			n1:       DecFixedPoint("10.5", MaxDecPointPrecision), // 10.50
+			n2:       DecFixedPoint("2.25", 0),                    // 2.00
+			expected: "21",                                        // 10.50 * 2.00 = 21.00
 		},
 	}
 
@@ -358,39 +357,51 @@ func TestDecFixedPointNumber_Div(t *testing.T) {
 	}{
 		{
 			name:     "same precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}, // 106.25
-			n2:       &DecFixedPointNumber{x: big.NewInt(425), prec: 2},   // 4.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(20), p: 1}, // 106.25
+			n2:       &DecFixedPointNumber{x: big.NewInt(1), p: 1},  // 4.25
+			expected: "20",
+		},
+		{
+			name:     "same precision",
+			n1:       &DecFixedPointNumber{x: big.NewInt(10625), p: 2}, // 106.25
+			n2:       &DecFixedPointNumber{x: big.NewInt(425), p: 2},   // 4.25
 			expected: "25",
 		},
 		{
 			name:     "first higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(106250), prec: 3}, // 106.250
-			n2:       &DecFixedPointNumber{x: big.NewInt(425), prec: 2},    // 4.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(106250), p: 3}, // 106.250
+			n2:       &DecFixedPointNumber{x: big.NewInt(425), p: 2},    // 4.25
 			expected: "25",
 		},
 		{
 			name:     "second higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}, // 106.25
-			n2:       &DecFixedPointNumber{x: big.NewInt(4250), prec: 3},  // 4.250
+			n1:       &DecFixedPointNumber{x: big.NewInt(10625), p: 2}, // 106.25
+			n2:       &DecFixedPointNumber{x: big.NewInt(4250), p: 3},  // 4.250
 			expected: "25",
 		},
 		{
 			name:     "maximum precision",
-			n1:       DecFixedPoint("106.25", math.MaxUint8), // 106.25
-			n2:       DecFixedPoint("4.25", math.MaxUint8),   // 4.25
+			n1:       DecFixedPoint("106.25", MaxDecPointPrecision), // 106.25
+			n2:       DecFixedPoint("4.25", MaxDecPointPrecision),   // 4.25
 			expected: "25",
 		},
 		{
 			name:     "zero and maximum precision",
-			n1:       DecFixedPoint("106.25", 0),           // 106.00
-			n2:       DecFixedPoint("4.25", math.MaxUint8), // 4.00 (precision of first number is 0)
-			expected: "26",                                 // 106.00 / 4.00 = 26.50 -> 26
+			n1:       DecFixedPoint("106.25", 0),                  // 106.00
+			n2:       DecFixedPoint("4.25", MaxDecPointPrecision), // 4.25
+			expected: "25",                                        // 106.00 / 4.25 = 24.94 -> 25
 		},
 		{
 			name:     "maximum and zero precision",
-			n1:       DecFixedPoint("106.25", math.MaxUint8), // 106.25
-			n2:       DecFixedPoint("4.25", 0),               // 4.00
-			expected: "26.5625",                              // 106.25 / 4.00 = 26.5625
+			n1:       DecFixedPoint("106.25", MaxDecPointPrecision), // 106.25
+			n2:       DecFixedPoint("4.25", 0),                      // 4.00
+			expected: "26.5625",                                     // 106.25 / 4.00 = 26.5625
+		},
+		{
+			name:     "guard digits",
+			n1:       DecFixedPoint("1", 1),   // 1.0
+			n2:       DecFixedPoint("1.5", 1), // 1.5
+			expected: "0.7",                   // 1.0 / 1.5 = 0.66 -> 0.7
 		},
 	}
 
@@ -411,32 +422,32 @@ func TestDecFixedPointNumber_Cmp(t *testing.T) {
 	}{
 		{
 			name:     "same precision equal",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}, // 106.25
-			n2:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}, // 106.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(10625), p: 2}, // 106.25
+			n2:       &DecFixedPointNumber{x: big.NewInt(10625), p: 2}, // 106.25
 			expected: 0,
 		},
 		{
 			name:     "same precision less than",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}, // 106.25
-			n2:       &DecFixedPointNumber{x: big.NewInt(20625), prec: 2}, // 206.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(10625), p: 2}, // 106.25
+			n2:       &DecFixedPointNumber{x: big.NewInt(20625), p: 2}, // 206.25
 			expected: -1,
 		},
 		{
 			name:     "same precision greater than",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}, // 106.25
-			n2:       &DecFixedPointNumber{x: big.NewInt(625), prec: 2},   // 6.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(10625), p: 2}, // 106.25
+			n2:       &DecFixedPointNumber{x: big.NewInt(625), p: 2},   // 6.25
 			expected: 1,
 		},
 		{
 			name:     "first higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(106250), prec: 3}, // 106.250
-			n2:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2},  // 106.25
+			n1:       &DecFixedPointNumber{x: big.NewInt(106250), p: 3}, // 106.250
+			n2:       &DecFixedPointNumber{x: big.NewInt(10625), p: 2},  // 106.25
 			expected: 0,
 		},
 		{
 			name:     "second higher precision",
-			n1:       &DecFixedPointNumber{x: big.NewInt(10625), prec: 2},  // 106.25
-			n2:       &DecFixedPointNumber{x: big.NewInt(106250), prec: 3}, // 106.250
+			n1:       &DecFixedPointNumber{x: big.NewInt(10625), p: 2},  // 106.25
+			n2:       &DecFixedPointNumber{x: big.NewInt(106250), p: 3}, // 106.250
 			expected: 0,
 		},
 	}
@@ -450,21 +461,21 @@ func TestDecFixedPointNumber_Cmp(t *testing.T) {
 }
 
 func TestDecFixedPointNumber_Abs(t *testing.T) {
-	number := &DecFixedPointNumber{x: big.NewInt(-10625), prec: 2} // -106.25
+	number := &DecFixedPointNumber{x: big.NewInt(-10625), p: 2} // -106.25
 
-	expectedAbs := &DecFixedPointNumber{x: big.NewInt(10625), prec: 2} // 106.25
+	expectedAbs := &DecFixedPointNumber{x: big.NewInt(10625), p: 2} // 106.25
 	resultAbs := number.Abs()
 	assert.Equal(t, expectedAbs.x, resultAbs.x)
-	assert.Equal(t, expectedAbs.prec, resultAbs.prec)
+	assert.Equal(t, expectedAbs.p, resultAbs.p)
 }
 
 func TestDecFixedPointNumber_Neg(t *testing.T) {
-	number := &DecFixedPointNumber{x: big.NewInt(10625), prec: 2} // 106.25
+	number := &DecFixedPointNumber{x: big.NewInt(10625), p: 2} // 106.25
 
-	expectedNeg := &DecFixedPointNumber{x: big.NewInt(-10625), prec: 2} // -106.25
+	expectedNeg := &DecFixedPointNumber{x: big.NewInt(-10625), p: 2} // -106.25
 	resultNeg := number.Neg()
 	assert.Equal(t, expectedNeg.x, resultNeg.x)
-	assert.Equal(t, expectedNeg.prec, resultNeg.prec)
+	assert.Equal(t, expectedNeg.p, resultNeg.p)
 }
 
 func TestDecFixedPointNumber_Inv(t *testing.T) {
@@ -475,13 +486,13 @@ func TestDecFixedPointNumber_Inv(t *testing.T) {
 	}{
 		{
 			name:     "0-digits",
-			number:   &DecFixedPointNumber{x: big.NewInt(106), prec: 0},
+			number:   &DecFixedPointNumber{x: big.NewInt(106), p: 0},
 			expected: "0",
 		},
 		{
 			name:     "6-digits",
-			number:   &DecFixedPointNumber{x: big.NewInt(106250000), prec: 6},
-			expected: "0.009411",
+			number:   &DecFixedPointNumber{x: big.NewInt(106250000), p: 6},
+			expected: "0.009412",
 		},
 	}
 
@@ -494,7 +505,7 @@ func TestDecFixedPointNumber_Inv(t *testing.T) {
 }
 
 func TestDecFixedPointNumber_MarshalBinary(t *testing.T) {
-	number := &DecFixedPointNumber{x: big.NewInt(10625), prec: 2} // 106.25
+	number := &DecFixedPointNumber{x: big.NewInt(10625), p: 2} // 106.25
 
 	data, err := number.MarshalBinary()
 	assert.NoError(t, err)
@@ -510,6 +521,6 @@ func TestDecFixedPointNumber_UnmarshalBinary(t *testing.T) {
 	err := number.UnmarshalBinary(data)
 	assert.NoError(t, err)
 
-	expectedNumber := &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}
+	expectedNumber := &DecFixedPointNumber{x: big.NewInt(10625), p: 2}
 	assert.Equal(t, expectedNumber, number)
 }

--- a/pkg/util/bn/decfloatpoint.go
+++ b/pkg/util/bn/decfloatpoint.go
@@ -162,11 +162,11 @@ func (x *DecFloatPointNumber) Sub(y *DecFloatPointNumber) *DecFloatPointNumber {
 
 // Mul multiplies the number by y and returns the result.
 func (x *DecFloatPointNumber) Mul(y *DecFloatPointNumber) *DecFloatPointNumber {
-	p := x.x.p + y.x.p
-	xi := bigIntSetPrec(x.x.x, uint32(x.x.p), uint32(p))
-	yi := bigIntSetPrec(y.x.x, uint32(y.x.p), uint32(p))
-	z := bigIntSetPrec(new(big.Int).Mul(xi, yi), uint32(p)*2, uint32(p))
-	n := &DecFloatPointNumber{x: &DecFixedPointNumber{x: z, p: p}}
+	p := uint32(x.x.p) + uint32(y.x.p)
+	xi := bigIntSetPrec(x.x.x, uint32(x.x.p), p)
+	yi := bigIntSetPrec(y.x.x, uint32(y.x.p), p)
+	z := bigIntSetPrec(new(big.Int).Mul(xi, yi), uint32(p)*2, p)
+	n := &DecFloatPointNumber{x: &DecFixedPointNumber{x: z, p: uint8(p)}}
 	n.adjustPrec()
 	return n
 }
@@ -175,15 +175,15 @@ func (x *DecFloatPointNumber) Mul(y *DecFloatPointNumber) *DecFloatPointNumber {
 //
 // Division by zero panics.
 //
-// During division, the precision is increased by divPrevisionIncrease and then
+// During division, the precision is increased by divPrecisionIncrease and then
 // lowered to the smallest possible that still fits the result.
 func (x *DecFloatPointNumber) Div(y *DecFloatPointNumber) *DecFloatPointNumber {
 	if y.x.Sign() == 0 {
 		panic("division by zero")
 	}
 	p := max(x.x.p, y.x.p)
-	wp := uint32(p + divPrevisionIncrease + divGuardDigits) // working precision
-	rp := uint32(p + divPrevisionIncrease)                  // result precision
+	wp := uint32(p + divPrecisionIncrease + divGuardDigits) // working precision
+	rp := uint32(p + divPrecisionIncrease)                  // result precision
 	if rp > MaxDecPointPrecision {
 		rp = MaxDecPointPrecision
 	}
@@ -239,21 +239,21 @@ func (x *DecFloatPointNumber) Neg() *DecFloatPointNumber {
 //
 // If x is zero, Inv panics.
 //
-// During inversion, the precision is increased by divPrevisionIncrease and
+// During inversion, the precision is increased by divPrecisionIncrease and
 // then lowered to the smallest possible that still fits the result.
 func (x *DecFloatPointNumber) Inv() *DecFloatPointNumber {
 	if x.x.Sign() == 0 {
 		panic("division by zero")
 	}
-	wp := uint32(x.x.p) + divPrevisionIncrease // working precision
-	rp := wp                                   // result precision
+	wp := uint32(x.x.p) + divPrecisionIncrease + divGuardDigits // working precision
+	rp := uint32(x.x.p) + divPrecisionIncrease                  // result precision
 	if rp > MaxDecPointPrecision {
 		rp = MaxDecPointPrecision
 	}
 	z := bigIntSetPrec(x.x.x, uint32(x.x.p), wp)
 	z = new(big.Int).Quo(pow10(wp*2), z)
 	z = bigIntSetPrec(z, wp, rp)
-	n := &DecFloatPointNumber{x: &DecFixedPointNumber{x: z, p: uint8(wp)}}
+	n := &DecFloatPointNumber{x: &DecFixedPointNumber{x: z, p: uint8(rp)}}
 	n.adjustPrec()
 	return n
 }

--- a/pkg/util/bn/decfloatpoint.go
+++ b/pkg/util/bn/decfloatpoint.go
@@ -165,7 +165,7 @@ func (x *DecFloatPointNumber) Mul(y *DecFloatPointNumber) *DecFloatPointNumber {
 	p := uint32(x.x.p) + uint32(y.x.p)
 	xi := bigIntSetPrec(x.x.x, uint32(x.x.p), p)
 	yi := bigIntSetPrec(y.x.x, uint32(y.x.p), p)
-	z := bigIntSetPrec(new(big.Int).Mul(xi, yi), uint32(p)*2, p)
+	z := bigIntSetPrec(new(big.Int).Mul(xi, yi), p*2, p)
 	n := &DecFloatPointNumber{x: &DecFixedPointNumber{x: z, p: uint8(p)}}
 	n.adjustPrec()
 	return n

--- a/pkg/util/bn/decfloatpoint.go
+++ b/pkg/util/bn/decfloatpoint.go
@@ -1,0 +1,280 @@
+//  Copyright (C) 2021-2023 Chronicle Labs, Inc.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package bn
+
+import (
+	"math"
+	"math/big"
+)
+
+// DecFloatPoint returns the DecFloatPointNumber representation of x.
+//
+// The argument x can be one of the following types:
+// - IntNumber
+// - FloatNumber
+// - DecFixedPointNumber
+// - DecFloatPointNumber
+// - big.Int
+// - big.Float
+// - int, int8, int16, int32, int64
+// - uint, uint8, uint16, uint32, uint64
+// - float32, float64
+// - string - a string accepted by big.Float.SetString, otherwise it returns nil
+//
+// If the input value is not one of the supported types, nil is returned.
+func DecFloatPoint(x any) *DecFloatPointNumber {
+	switch x := x.(type) {
+	case IntNumber:
+		return convertIntToDecFloatPoint(&x)
+	case *IntNumber:
+		return convertIntToDecFloatPoint(x)
+	case FloatNumber:
+		return convertFloatToDecFloatPoint(&x)
+	case *FloatNumber:
+		return convertFloatToDecFloatPoint(x)
+	case DecFixedPointNumber:
+		return convertDecFixedPointToDecFloatPoint(&x)
+	case *DecFixedPointNumber:
+		return convertDecFixedPointToDecFloatPoint(x)
+	case DecFloatPointNumber:
+		return &x
+	case *DecFloatPointNumber:
+		return x
+	case *big.Int:
+		return convertBigIntToDecFloatPoint(x)
+	case *big.Float:
+		return convertBigFloatToDecFloatPoint(x)
+	case int, int8, int16, int32, int64:
+		return convertInt64ToDecFloatPoint(anyToInt64(x))
+	case uint, uint8, uint16, uint32, uint64:
+		return convertUint64ToDecFloatPoint(anyToUint64(x))
+	case float32, float64:
+		return convertFloat64ToDecFloatPoint(anyToFloat64(x))
+	case string:
+		return convertStringToDecFloatPoint(x)
+	}
+	return nil
+}
+
+// DecFloatPointNumber represents a decimal floating-point number.
+//
+// Unlike the DecFixedPointNumber, the precision of the DecFloatPointNumber is
+// not fixed. The precision is dynamically adjusted to fit the number.
+type DecFloatPointNumber struct {
+	x *DecFixedPointNumber
+}
+
+// Int returns the Int representation of the DecFloatPointNumber.
+func (x *DecFloatPointNumber) Int() *IntNumber {
+	return convertDecFloatPointToInt(x)
+}
+
+// DecFixedPoint returns the DecFixedPointNumber representation of the Float.
+func (x *DecFloatPointNumber) DecFixedPoint(n uint8) *DecFixedPointNumber {
+	return convertDecFloatPointToDecFixedPoint(x, n)
+}
+
+// Float returns the Float representation of the DecFloatPointNumber.
+func (x *DecFloatPointNumber) Float() *FloatNumber {
+	return convertDecFloatPointToFloat(x)
+}
+
+// BigInt returns the *big.Int representation of the DecFloatPointNumber.
+func (x *DecFloatPointNumber) BigInt() *big.Int {
+	return x.x.BigInt()
+}
+
+// BigFloat returns the *big.Float representation of the DecFloatPointNumber.
+func (x *DecFloatPointNumber) BigFloat() *big.Float {
+	return x.x.BigFloat()
+}
+
+// String returns the 10-base string representation of the DecFloatPointNumber.
+func (x *DecFloatPointNumber) String() string {
+	return x.x.String()
+}
+
+// Text returns the string representation of the DecFloatPointNumber.
+// The format and prec arguments are the same as in big.Float.Text.
+//
+// For any format other than 'f' and prec of -1, the result may be rounded.
+func (x *DecFloatPointNumber) Text(format byte, prec int) string {
+	if format == 'f' && prec < 0 {
+		return x.x.String()
+	}
+	return x.x.Text(format, prec)
+}
+
+// Precision returns the precision of the DecFloatPointNumber.
+//
+// Precision is the number of decimal digits in the fractional part.
+func (x *DecFloatPointNumber) Precision() uint8 {
+	return x.x.Precision()
+}
+
+// SetPrecision returns a new DecFloatPointNumber with the given precision.
+//
+// Precision is the number of decimal digits in the fractional part.
+func (x *DecFloatPointNumber) SetPrecision(n uint8) *DecFloatPointNumber {
+	if n == x.x.prec {
+		return x
+	}
+	return &DecFloatPointNumber{x: x.x.SetPrecision(n)}
+}
+
+// Sign returns:
+//
+//	-1 if x <  0
+//	 0 if x == 0
+//	+1 if x >  0
+func (x *DecFloatPointNumber) Sign() int {
+	return x.x.Sign()
+}
+
+// Add adds y to the number and returns the result.
+//
+// The y argument can be any of the types accepted by DecFloatPointNumber.
+//
+// The precision is adjusted to fit the result.
+func (x *DecFloatPointNumber) Add(y any) *DecFloatPointNumber {
+	f := DecFloatPoint(y)
+	p := x.x.prec
+	if f.x.prec > p {
+		p = f.x.prec
+	}
+	a := x.x.SetPrecision(p)
+	b := f.x.SetPrecision(p)
+	return (&DecFloatPointNumber{x: a.Add(b)}).setMinimumPrecision()
+}
+
+// Sub subtracts y from the number and returns the result.
+//
+// The y argument can be any of the types accepted by DecFloatPointNumber.
+//
+// The precision is adjusted to fit the result.
+func (x *DecFloatPointNumber) Sub(y any) *DecFloatPointNumber {
+	f := DecFloatPoint(y)
+	p := x.x.prec
+	if f.x.prec > p {
+		p = f.x.prec
+	}
+	a := x.x.SetPrecision(p)
+	b := f.x.SetPrecision(p)
+	return (&DecFloatPointNumber{x: a.Sub(b)}).setMinimumPrecision()
+}
+
+// Mul multiplies the number by y and returns the result.
+//
+// The y argument can be any of the types accepted by DecFloatPointNumber.
+//
+// The precision is adjusted to fit the result.
+func (x *DecFloatPointNumber) Mul(y any) *DecFloatPointNumber {
+	f := DecFloatPoint(y)
+	px := int(f.x.prec)
+	py := int(x.x.prec)
+	p := px + py
+	if p > math.MaxUint8 {
+		p = math.MaxUint8
+	}
+	a := x.x.SetPrecision(uint8(p))
+	b := f.x.SetPrecision(uint8(p))
+	return (&DecFloatPointNumber{x: a.Mul(b)}).setMinimumPrecision()
+}
+
+// Div divides the number by y and returns the result.
+//
+// Division by zero panics.
+//
+// The y argument can be any of the types accepted by DecFloatPointNumber.
+//
+// The precision is adjusted to fit the result.
+func (x *DecFloatPointNumber) Div(y any) *DecFloatPointNumber {
+	f := DecFloatPoint(y)
+	a := x.x.SetPrecision(math.MaxUint8)
+	b := f.x.SetPrecision(math.MaxUint8)
+	return (&DecFloatPointNumber{x: a.Div(b)}).setMinimumPrecision()
+}
+
+// Cmp compares the number to y and returns:
+//
+//	-1 if x <  0
+//	 0 if x == 0
+//	+1 if x >  0
+//
+// The y argument can be any of the types accepted by DecFloatPointNumber.
+func (x *DecFloatPointNumber) Cmp(y any) int {
+	return x.x.Cmp(DecFloatPoint(y).x)
+}
+
+// Abs returns the absolute number of x.
+func (x *DecFloatPointNumber) Abs() *DecFloatPointNumber {
+	return &DecFloatPointNumber{x: x.x.Abs()}
+}
+
+// Neg returns the negative number of x.
+func (x *DecFloatPointNumber) Neg() *DecFloatPointNumber {
+	return &DecFloatPointNumber{x: x.x.Neg()}
+}
+
+// Inv returns the inverse value of the number of x.
+//
+// If x is zero, Inv panics.
+func (x *DecFloatPointNumber) Inv() *DecFloatPointNumber {
+	if x.x.Sign() == 0 {
+		panic("division by zero")
+	}
+	i := x.Float().Inv()
+	p := stringNumberDecimalPrecision(i.Text('f', -1))
+	if p > math.MaxUint8 {
+		p = math.MaxUint8
+	}
+	i = i.Mul(pow10(p))
+	return &DecFloatPointNumber{x: &DecFixedPointNumber{x: i.BigInt(), prec: uint8(p)}}
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface.
+func (x *DecFloatPointNumber) MarshalBinary() (data []byte, err error) {
+	return x.x.MarshalBinary()
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+func (x *DecFloatPointNumber) UnmarshalBinary(data []byte) error {
+	x.x = new(DecFixedPointNumber)
+	return x.x.UnmarshalBinary(data)
+}
+
+// setMinimumPrecision sets the precision to the lowest possible precision
+// required to represent the number.
+func (x *DecFloatPointNumber) setMinimumPrecision() *DecFloatPointNumber {
+	str := x.x.x.String()
+	tz := 0
+	for i := len(str) - 1; i >= 0; i-- {
+		if str[i] == '0' {
+			tz++
+		} else {
+			break
+		}
+	}
+	prec := int(x.x.prec) - tz
+	if prec < 0 {
+		prec = 0
+	}
+	if prec > math.MaxUint8 {
+		prec = math.MaxUint8
+	}
+	x.x = x.x.SetPrecision(uint8(prec))
+	return x
+}

--- a/pkg/util/bn/decfloatpoint_test.go
+++ b/pkg/util/bn/decfloatpoint_test.go
@@ -17,6 +17,7 @@ package bn
 
 import (
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -347,8 +348,14 @@ func TestDecFloatPointNumber_Inv(t *testing.T) {
 		{
 			name:         "106.25",
 			number:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), p: 2}},
-			expectedNum:  "0.009411764705882352",
+			expectedNum:  "0.009411764705882353",
 			expectedPrec: 18,
+		},
+		{
+			name:         "large precision",
+			number:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: new(big.Int).Add(pow10(255), big.NewInt(1)), p: 255}},
+			expectedNum:  "0." + strings.Repeat("9", 255),
+			expectedPrec: 255,
 		},
 	}
 

--- a/pkg/util/bn/decfloatpoint_test.go
+++ b/pkg/util/bn/decfloatpoint_test.go
@@ -1,0 +1,326 @@
+//  Copyright (C) 2021-2023 Chronicle Labs, Inc.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package bn
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecFloatPoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected *DecFloatPointNumber
+	}{
+		{
+			name:     "IntNumber",
+			input:    IntNumber{big.NewInt(42)},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(42), prec: 0}},
+		},
+		{
+			name:     "*IntNumber",
+			input:    &IntNumber{big.NewInt(42)},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(42), prec: 0}},
+		},
+		{
+			name:     "FloatNumber",
+			input:    FloatNumber{big.NewFloat(42.5)},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), prec: 1}},
+		},
+		{
+			name:     "*FloatNumber",
+			input:    &FloatNumber{big.NewFloat(42.5)},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), prec: 1}},
+		},
+		{
+			name:     "DecFixedPointNumber",
+			input:    DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+		},
+		{
+			name:     "*DecFixedPointNumber",
+			input:    &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+		},
+		{
+			name:     "DecFloatPointNumber",
+			input:    DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+		},
+		{
+			name:     "*DecFloatPointNumber",
+			input:    &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+		},
+		{
+			name:     "big.Int",
+			input:    big.NewInt(42),
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(42), prec: 0}},
+		},
+		{
+			name:     "big.Float",
+			input:    big.NewFloat(42.5),
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), prec: 1}},
+		},
+		{
+			name:     "int",
+			input:    int(42),
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(42), prec: 0}},
+		},
+		{
+			name:     "float64",
+			input:    float64(42.5),
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), prec: 1}},
+		},
+		{
+			name:     "string",
+			input:    "42.5",
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), prec: 1}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := DecFloatPoint(test.input)
+			if test.expected == nil {
+				assert.Nil(t, result)
+			} else {
+				assert.Equal(t, test.expected.String(), result.String())
+				assert.Equal(t, test.expected.Precision(), result.Precision())
+			}
+		})
+	}
+}
+
+func TestDecFloatPointNumber_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		n        *DecFloatPointNumber
+		expected string
+	}{
+		{
+			name:     "zero precision",
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), prec: 0}}, // 10625
+			expected: "10625",
+		},
+		{
+			name:     "two digits precision",
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}}, // 106.25
+			expected: "106.25",
+		},
+		{
+			name:     "ten digits precision",
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), prec: 10}}, // 0.0000010625
+			expected: "0.0000010625",
+		},
+		{
+			name:     "zero precision negative",
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), prec: 0}}, // -10625
+			expected: "-10625",
+		},
+		{
+			name:     "two digits precision negative",
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), prec: 2}}, // -106.25
+			expected: "-106.25",
+		},
+		{
+			name:     "ten digits precision negative",
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), prec: 10}}, // -0.0000010625
+			expected: "-0.0000010625",
+		},
+		{
+			name:     "remove trailing zeros",
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1062500), prec: 4}}, // 106.2500
+			expected: "106.25",
+		},
+		{
+			name:     "remove trailing zeros (no fractional part)",
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1060000), prec: 4}}, // 1062500
+			expected: "106",
+		},
+		{
+			name:     "remove trailing zeros (no integer part)",
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1062500), prec: 10}}, // 0.1062500
+			expected: "0.00010625",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.n.String())
+		})
+	}
+}
+
+func TestDecFloatPointNumber_Add(t *testing.T) {
+	tests := []struct {
+		name         string
+		n1           *DecFloatPointNumber
+		n2           *DecFloatPointNumber
+		expectedPrec uint8
+		expectedNum  string
+	}{
+		{
+			name:         "same precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), prec: 3}}, // 10.50
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}},  // 2.25
+			expectedPrec: 2,
+			expectedNum:  "12.75",
+		},
+		{
+			name:         "first higher precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), prec: 3}}, // 10.500
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), prec: 2}},   // 2.25
+			expectedPrec: 2,
+			expectedNum:  "12.75",
+		},
+		{
+			name:         "second higher precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}}, // 10.50
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}}, // 2.250
+			expectedPrec: 2,
+			expectedNum:  "12.75",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.n1.Add(tt.n2)
+			assert.Equal(t, tt.expectedNum, result.String())
+			assert.Equal(t, tt.expectedPrec, result.Precision())
+		})
+	}
+}
+
+func TestDecFloatPointNumber_Sub(t *testing.T) {
+	tests := []struct {
+		name     string
+		n1       *DecFloatPointNumber
+		n2       *DecFloatPointNumber
+		expected string
+	}{
+		{
+			name:     "same precision",
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}}, // 10.50
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), prec: 2}},  // 2.25
+			expected: "8.25",
+		},
+		{
+			name:     "first higher precision",
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), prec: 3}}, // 10.500
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), prec: 2}},   // 2.25
+			expected: "8.25",
+		},
+		{
+			name:     "second higher precision",
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}}, // 10.50
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}}, // 2.250
+			expected: "8.25",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.n1.Sub(tt.n2)
+			assert.Equal(t, tt.expected, result.String())
+		})
+	}
+}
+
+func TestDecFloatPointNumber_Mul(t *testing.T) {
+	tests := []struct {
+		name     string
+		n1       *DecFloatPointNumber
+		n2       *DecFloatPointNumber
+		expected string
+	}{
+		{
+			name:     "same precision",
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}}, // 10.50
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), prec: 2}},  // 2.25
+			expected: "23.625",
+		},
+		{
+			name:     "first higher precision",
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), prec: 3}}, // 10.500
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), prec: 2}},   // 2.25
+			expected: "23.625",
+		},
+		{
+			name:     "second higher precision",
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}}, // 10.50
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}}, // 2.250
+			expected: "23.625",
+		},
+		{
+			name:     "second higher precision",
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}}, // 10.50
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}}, // 2.250
+			expected: "23.625",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.n1.Mul(tt.n2)
+			assert.Equal(t, tt.expected, result.String())
+		})
+	}
+}
+
+func TestDecFloatPointNumber_Div(t *testing.T) {
+	tests := []struct {
+		name     string
+		n1       *DecFloatPointNumber
+		n2       *DecFloatPointNumber
+		expected string
+	}{
+		{
+			name:     "same precision",
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}}, // 106.25
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), prec: 2}},   // 4.25
+			expected: "25",
+		},
+		{
+			name:     "first higher precision",
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(106250), prec: 3}}, // 106.250
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), prec: 2}},    // 4.25
+			expected: "25",
+		},
+		{
+			name:     "second higher precision",
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}}, // 106.25
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 3}},  // 4.250
+			expected: "25",
+		},
+		{
+			name:     "infinite precision",
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1), prec: 0}}, // 1
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(3), prec: 0}}, // 3
+			expected: "0.333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.n1.Div(tt.n2)
+			assert.Equal(t, tt.expected, result.String())
+		})
+	}
+}

--- a/pkg/util/bn/decfloatpoint_test.go
+++ b/pkg/util/bn/decfloatpoint_test.go
@@ -31,67 +31,67 @@ func TestDecFloatPoint(t *testing.T) {
 		{
 			name:     "IntNumber",
 			input:    IntNumber{big.NewInt(42)},
-			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(42), prec: 0}},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(42), p: 0}},
 		},
 		{
 			name:     "*IntNumber",
 			input:    &IntNumber{big.NewInt(42)},
-			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(42), prec: 0}},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(42), p: 0}},
 		},
 		{
 			name:     "FloatNumber",
 			input:    FloatNumber{big.NewFloat(42.5)},
-			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), prec: 1}},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), p: 1}},
 		},
 		{
 			name:     "*FloatNumber",
 			input:    &FloatNumber{big.NewFloat(42.5)},
-			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), prec: 1}},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), p: 1}},
 		},
 		{
 			name:     "DecFixedPointNumber",
-			input:    DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
-			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+			input:    DecFixedPointNumber{x: big.NewInt(4250), p: 2},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), p: 2}},
 		},
 		{
 			name:     "*DecFixedPointNumber",
-			input:    &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
-			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+			input:    &DecFixedPointNumber{x: big.NewInt(4250), p: 2},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), p: 2}},
 		},
 		{
 			name:     "DecFloatPointNumber",
-			input:    DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
-			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+			input:    DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), p: 2}},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), p: 2}},
 		},
 		{
 			name:     "*DecFloatPointNumber",
-			input:    &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
-			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+			input:    &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), p: 2}},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), p: 2}},
 		},
 		{
 			name:     "big.Int",
 			input:    big.NewInt(42),
-			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(42), prec: 0}},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(42), p: 0}},
 		},
 		{
 			name:     "big.Float",
 			input:    big.NewFloat(42.5),
-			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), prec: 1}},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), p: 1}},
 		},
 		{
 			name:     "int",
 			input:    int(42),
-			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(42), prec: 0}},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(42), p: 0}},
 		},
 		{
 			name:     "float64",
 			input:    float64(42.5),
-			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), prec: 1}},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), p: 1}},
 		},
 		{
 			name:     "string",
 			input:    "42.5",
-			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), prec: 1}},
+			expected: &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), p: 1}},
 		},
 	}
 
@@ -102,7 +102,7 @@ func TestDecFloatPoint(t *testing.T) {
 				assert.Nil(t, result)
 			} else {
 				assert.Equal(t, test.expected.String(), result.String())
-				assert.Equal(t, test.expected.Precision(), result.Precision())
+				assert.Equal(t, test.expected.Prec(), result.Prec())
 			}
 		})
 	}
@@ -116,47 +116,47 @@ func TestDecFloatPointNumber_String(t *testing.T) {
 	}{
 		{
 			name:     "zero precision",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), prec: 0}}, // 10625
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), p: 0}}, // 10625
 			expected: "10625",
 		},
 		{
 			name:     "two digits precision",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}}, // 106.25
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), p: 2}}, // 106.25
 			expected: "106.25",
 		},
 		{
 			name:     "ten digits precision",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), prec: 10}}, // 0.0000010625
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), p: 10}}, // 0.0000010625
 			expected: "0.0000010625",
 		},
 		{
 			name:     "zero precision negative",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), prec: 0}}, // -10625
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), p: 0}}, // -10625
 			expected: "-10625",
 		},
 		{
 			name:     "two digits precision negative",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), prec: 2}}, // -106.25
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), p: 2}}, // -106.25
 			expected: "-106.25",
 		},
 		{
 			name:     "ten digits precision negative",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), prec: 10}}, // -0.0000010625
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), p: 10}}, // -0.0000010625
 			expected: "-0.0000010625",
 		},
 		{
 			name:     "remove trailing zeros",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1062500), prec: 4}}, // 106.2500
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1062500), p: 4}}, // 106.2500
 			expected: "106.25",
 		},
 		{
 			name:     "remove trailing zeros (no fractional part)",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1060000), prec: 4}}, // 1062500
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1060000), p: 4}}, // 1062500
 			expected: "106",
 		},
 		{
 			name:     "remove trailing zeros (no integer part)",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1062500), prec: 10}}, // 0.1062500
+			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1062500), p: 10}}, // 0.1062500
 			expected: "0.00010625",
 		},
 	}
@@ -178,22 +178,22 @@ func TestDecFloatPointNumber_Add(t *testing.T) {
 	}{
 		{
 			name:         "same precision",
-			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), prec: 3}}, // 10.50
-			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}},  // 2.25
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), p: 3}}, // 10.50
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), p: 3}},  // 2.25
 			expectedPrec: 2,
 			expectedNum:  "12.75",
 		},
 		{
 			name:         "first higher precision",
-			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), prec: 3}}, // 10.500
-			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), prec: 2}},   // 2.25
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), p: 3}}, // 10.500
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), p: 2}},   // 2.25
 			expectedPrec: 2,
 			expectedNum:  "12.75",
 		},
 		{
 			name:         "second higher precision",
-			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}}, // 10.50
-			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}}, // 2.250
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), p: 3}}, // 2.250
 			expectedPrec: 2,
 			expectedNum:  "12.75",
 		},
@@ -203,7 +203,7 @@ func TestDecFloatPointNumber_Add(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.n1.Add(tt.n2)
 			assert.Equal(t, tt.expectedNum, result.String())
-			assert.Equal(t, tt.expectedPrec, result.Precision())
+			assert.Equal(t, tt.expectedPrec, result.Prec())
 		})
 	}
 }
@@ -217,20 +217,20 @@ func TestDecFloatPointNumber_Sub(t *testing.T) {
 	}{
 		{
 			name:     "same precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}}, // 10.50
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), prec: 2}},  // 2.25
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), p: 2}},  // 2.25
 			expected: "8.25",
 		},
 		{
 			name:     "first higher precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), prec: 3}}, // 10.500
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), prec: 2}},   // 2.25
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), p: 3}}, // 10.500
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), p: 2}},   // 2.25
 			expected: "8.25",
 		},
 		{
 			name:     "second higher precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}}, // 10.50
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}}, // 2.250
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), p: 3}}, // 2.250
 			expected: "8.25",
 		},
 	}
@@ -252,26 +252,26 @@ func TestDecFloatPointNumber_Mul(t *testing.T) {
 	}{
 		{
 			name:     "same precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}}, // 10.50
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), prec: 2}},  // 2.25
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), p: 2}},  // 2.25
 			expected: "23.625",
 		},
 		{
 			name:     "first higher precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), prec: 3}}, // 10.500
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), prec: 2}},   // 2.25
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), p: 3}}, // 10.500
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), p: 2}},   // 2.25
 			expected: "23.625",
 		},
 		{
 			name:     "second higher precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}}, // 10.50
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}}, // 2.250
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), p: 3}}, // 2.250
 			expected: "23.625",
 		},
 		{
 			name:     "second higher precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), prec: 2}}, // 10.50
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), prec: 3}}, // 2.250
+			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
+			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), p: 3}}, // 2.250
 			expected: "23.625",
 		},
 	}
@@ -286,41 +286,161 @@ func TestDecFloatPointNumber_Mul(t *testing.T) {
 
 func TestDecFloatPointNumber_Div(t *testing.T) {
 	tests := []struct {
-		name     string
-		n1       *DecFloatPointNumber
-		n2       *DecFloatPointNumber
-		expected string
+		name         string
+		n1           *DecFloatPointNumber
+		n2           *DecFloatPointNumber
+		expectedNum  string
+		expectedPrec uint8
 	}{
 		{
-			name:     "same precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}}, // 106.25
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), prec: 2}},   // 4.25
-			expected: "25",
+			name:         "same precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), p: 2}}, // 106.25
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), p: 2}},   // 4.25
+			expectedNum:  "25",                                                                      // 106.25 / 4.25 = 25
+			expectedPrec: 0,
 		},
 		{
-			name:     "first higher precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(106250), prec: 3}}, // 106.250
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(425), prec: 2}},    // 4.25
-			expected: "25",
+			name:         "precision increase",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1), p: 0}}, // 1
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(3), p: 0}}, // 3
+			expectedNum:  "0.3333333333333333",                                                  // 1 / 3 = 0.3333333333333333
+			expectedPrec: 16,
 		},
 		{
-			name:     "second higher precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), prec: 2}}, // 106.25
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 3}},  // 4.250
-			expected: "25",
+			name:         "adjust precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(5185185138), p: 7}}, // 518.5185138
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1234567890), p: 8}}, // 12.34567890
+			expectedNum:  "42",                                                                           // 518.5185138 / 12.34567890 = 42
+			expectedPrec: 0,
 		},
 		{
-			name:     "infinite precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1), prec: 0}}, // 1
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(3), prec: 0}}, // 3
-			expected: "0.333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
+			name:         "guard digits",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10), p: 1}}, // 1.0
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(15), p: 1}}, // 1.5
+			expectedNum:  "0.66666666666666667",                                                  // 1.0 / 1.5 = 0.66666666666666667
+			expectedPrec: 17,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.n1.Div(tt.n2)
-			assert.Equal(t, tt.expected, result.String())
+			assert.Equal(t, tt.expectedNum, result.String())
+			assert.Equal(t, tt.expectedPrec, result.Prec())
+		})
+	}
+}
+
+func TestDecFloatPointNumber_Inv(t *testing.T) {
+	tests := []struct {
+		name         string
+		number       *DecFloatPointNumber
+		expectedNum  string
+		expectedPrec uint8
+	}{
+		{
+			name:         "106",
+			number:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(106), p: 0}},
+			expectedNum:  "0.0094339622641509",
+			expectedPrec: 16,
+		},
+		{
+			name:         "106.25",
+			number:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), p: 2}},
+			expectedNum:  "0.009411764705882352",
+			expectedPrec: 18,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.number.Inv()
+			assert.Equal(t, tt.expectedNum, result.String())
+			assert.Equal(t, tt.expectedPrec, result.Prec())
+		})
+	}
+}
+
+func TestDecFloatPointNumber_adjustPrec(t *testing.T) {
+	tests := []struct {
+		name         string
+		n            *DecFloatPointNumber
+		expectedNum  string
+		expectedPrec uint8
+	}{
+		{
+			name:         "no change",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(105), p: 1}}, // 10.5
+			expectedNum:  "10.5",
+			expectedPrec: 1,
+		},
+		{
+			name:         "decrease by 1",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
+			expectedNum:  "10.5",
+			expectedPrec: 1,
+		},
+		{
+			name:         "decrease by 6",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(105000000), p: 7}}, // 10.50000
+			expectedNum:  "10.5",
+			expectedPrec: 1,
+		},
+		{
+			name:         "10^10/10^9",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: pow10(10), p: 9}}, // 10
+			expectedNum:  "10",
+			expectedPrec: 0,
+		},
+		{
+			name:         "10^10/10^10",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: pow10(10), p: 10}}, // 1
+			expectedNum:  "1",
+			expectedPrec: 0,
+		},
+		{
+			name:         "10^10/10^11",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: pow10(10), p: 11}}, // 0.1
+			expectedNum:  "0.1",
+			expectedPrec: 1,
+		},
+		{
+			name:         "10^max/10^(max-1)",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision - 1}}, // 10
+			expectedNum:  "10",
+			expectedPrec: 0,
+		},
+		{
+			name:         "10^(max+1)/10^max",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: pow10(MaxDecPointPrecision + 1), p: MaxDecPointPrecision}}, // 10
+			expectedNum:  "10",
+			expectedPrec: 0,
+		},
+		{
+			name:         "10^max/10^max",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision}}, // 1
+			expectedNum:  "1",
+			expectedPrec: 0,
+		},
+		{
+			name:         "0/0",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(0), p: 0}}, // 0
+			expectedNum:  "0",
+			expectedPrec: 0,
+		},
+		{
+			name:         "0/max",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(0), p: MaxDecPointPrecision}}, // 0
+			expectedNum:  "0",
+			expectedPrec: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.n.adjustPrec()
+			assert.Equal(t, tt.expectedNum, tt.n.String())
+			assert.Equal(t, tt.expectedPrec, tt.n.Prec())
 		})
 	}
 }

--- a/pkg/util/bn/decfloatpoint_test.go
+++ b/pkg/util/bn/decfloatpoint_test.go
@@ -111,60 +111,71 @@ func TestDecFloatPoint(t *testing.T) {
 
 func TestDecFloatPointNumber_String(t *testing.T) {
 	tests := []struct {
-		name     string
-		n        *DecFloatPointNumber
-		expected string
+		name         string
+		n            *DecFloatPointNumber
+		expectedNum  string
+		expectedPrec uint8
 	}{
 		{
-			name:     "zero precision",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), p: 0}}, // 10625
-			expected: "10625",
+			name:         "zero precision",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), p: 0}}, // 10625
+			expectedNum:  "10625",
+			expectedPrec: 0,
 		},
 		{
-			name:     "two digits precision",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), p: 2}}, // 106.25
-			expected: "106.25",
+			name:         "two digits precision",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), p: 2}}, // 106.25
+			expectedNum:  "106.25",
+			expectedPrec: 2,
 		},
 		{
-			name:     "ten digits precision",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), p: 10}}, // 0.0000010625
-			expected: "0.0000010625",
+			name:         "ten digits precision",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), p: 10}}, // 0.0000010625
+			expectedNum:  "0.0000010625",
+			expectedPrec: 10,
 		},
 		{
-			name:     "zero precision negative",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), p: 0}}, // -10625
-			expected: "-10625",
+			name:         "zero precision negative",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), p: 0}}, // -10625
+			expectedNum:  "-10625",
+			expectedPrec: 0,
 		},
 		{
-			name:     "two digits precision negative",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), p: 2}}, // -106.25
-			expected: "-106.25",
+			name:         "two digits precision negative",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), p: 2}}, // -106.25
+			expectedNum:  "-106.25",
+			expectedPrec: 2,
 		},
 		{
-			name:     "ten digits precision negative",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), p: 10}}, // -0.0000010625
-			expected: "-0.0000010625",
+			name:         "ten digits precision negative",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(-10625), p: 10}}, // -0.0000010625
+			expectedNum:  "-0.0000010625",
+			expectedPrec: 10,
 		},
 		{
-			name:     "remove trailing zeros",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1062500), p: 4}}, // 106.2500
-			expected: "106.25",
+			name:         "remove trailing zeros",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1062500), p: 4}}, // 106.2500
+			expectedNum:  "106.25",
+			expectedPrec: 4,
 		},
 		{
-			name:     "remove trailing zeros (no fractional part)",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1060000), p: 4}}, // 1062500
-			expected: "106",
+			name:         "remove trailing zeros (no fractional part)",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1060000), p: 4}}, // 1062500
+			expectedNum:  "106",
+			expectedPrec: 4,
 		},
 		{
-			name:     "remove trailing zeros (no integer part)",
-			n:        &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1062500), p: 10}}, // 0.1062500
-			expected: "0.00010625",
+			name:         "remove trailing zeros (no integer part)",
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1062500), p: 10}}, // 0.1062500
+			expectedNum:  "0.00010625",
+			expectedPrec: 10,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.n.String())
+			assert.Equal(t, tt.expectedNum, tt.n.String())
+			assert.Equal(t, tt.expectedPrec, tt.n.Prec())
 		})
 	}
 }
@@ -174,29 +185,36 @@ func TestDecFloatPointNumber_Add(t *testing.T) {
 		name         string
 		n1           *DecFloatPointNumber
 		n2           *DecFloatPointNumber
-		expectedPrec uint8
 		expectedNum  string
+		expectedPrec uint8
 	}{
 		{
 			name:         "same precision",
 			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), p: 3}}, // 10.50
 			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), p: 3}},  // 2.25
-			expectedPrec: 2,
 			expectedNum:  "12.75",
+			expectedPrec: 2,
 		},
 		{
 			name:         "first higher precision",
 			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), p: 3}}, // 10.500
 			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), p: 2}},   // 2.25
-			expectedPrec: 2,
 			expectedNum:  "12.75",
+			expectedPrec: 2,
 		},
 		{
 			name:         "second higher precision",
 			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
 			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), p: 3}}, // 2.250
-			expectedPrec: 2,
 			expectedNum:  "12.75",
+			expectedPrec: 2,
+		},
+		{
+			name:         "large precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision}},
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision}},
+			expectedNum:  "2",
+			expectedPrec: 0,
 		},
 	}
 
@@ -211,76 +229,101 @@ func TestDecFloatPointNumber_Add(t *testing.T) {
 
 func TestDecFloatPointNumber_Sub(t *testing.T) {
 	tests := []struct {
-		name     string
-		n1       *DecFloatPointNumber
-		n2       *DecFloatPointNumber
-		expected string
+		name         string
+		n1           *DecFloatPointNumber
+		n2           *DecFloatPointNumber
+		expectedNum  string
+		expectedPrec uint8
 	}{
 		{
-			name:     "same precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), p: 2}},  // 2.25
-			expected: "8.25",
+			name:         "same precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), p: 2}},  // 2.25
+			expectedNum:  "8.25",
+			expectedPrec: 2,
 		},
 		{
-			name:     "first higher precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), p: 3}}, // 10.500
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), p: 2}},   // 2.25
-			expected: "8.25",
+			name:         "first higher precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), p: 3}}, // 10.500
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), p: 2}},   // 2.25
+			expectedNum:  "8.25",
+			expectedPrec: 2,
 		},
 		{
-			name:     "second higher precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), p: 3}}, // 2.250
-			expected: "8.25",
+			name:         "second higher precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), p: 3}}, // 2.250
+			expectedNum:  "8.25",
+			expectedPrec: 2,
+		},
+		{
+			name:         "large precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision}},
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision}},
+			expectedNum:  "0",
+			expectedPrec: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.n1.Sub(tt.n2)
-			assert.Equal(t, tt.expected, result.String())
+			assert.Equal(t, tt.expectedNum, result.String())
+			assert.Equal(t, tt.expectedPrec, result.Prec())
 		})
 	}
 }
 
 func TestDecFloatPointNumber_Mul(t *testing.T) {
 	tests := []struct {
-		name     string
-		n1       *DecFloatPointNumber
-		n2       *DecFloatPointNumber
-		expected string
+		name         string
+		n1           *DecFloatPointNumber
+		n2           *DecFloatPointNumber
+		expectedNum  string
+		expectedPrec uint8
 	}{
 		{
-			name:     "same precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), p: 2}},  // 2.25
-			expected: "23.625",
+			name:         "same precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), p: 2}},  // 2.25
+			expectedNum:  "23.625",
+			expectedPrec: 3,
 		},
 		{
-			name:     "first higher precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), p: 3}}, // 10.500
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), p: 2}},   // 2.25
-			expected: "23.625",
+			name:         "first higher precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10500), p: 3}}, // 10.500
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(225), p: 2}},   // 2.25
+			expectedNum:  "23.625",
+			expectedPrec: 3,
 		},
 		{
-			name:     "second higher precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), p: 3}}, // 2.250
-			expected: "23.625",
+			name:         "second higher precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), p: 3}}, // 2.250
+			expectedNum:  "23.625",
+			expectedPrec: 3,
 		},
 		{
-			name:     "second higher precision",
-			n1:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
-			n2:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), p: 3}}, // 2.250
-			expected: "23.625",
+			name:         "second higher precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(1050), p: 2}}, // 10.50
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(2250), p: 3}}, // 2.250
+			expectedNum:  "23.625",
+			expectedPrec: 3,
+		},
+		{
+			name:         "large precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision}},
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision}},
+			expectedNum:  "1",
+			expectedPrec: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.n1.Mul(tt.n2)
-			assert.Equal(t, tt.expected, result.String())
+			assert.Equal(t, tt.expectedNum, result.String())
+			assert.Equal(t, tt.expectedPrec, result.Prec())
 		})
 	}
 }
@@ -321,6 +364,13 @@ func TestDecFloatPointNumber_Div(t *testing.T) {
 			expectedNum:  "0.66666666666666667",                                                  // 1.0 / 1.5 = 0.66666666666666667
 			expectedPrec: 17,
 		},
+		{
+			name:         "large precision",
+			n1:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision}},
+			n2:           &DecFloatPointNumber{x: &DecFixedPointNumber{x: pow10(MaxDecPointPrecision), p: MaxDecPointPrecision}},
+			expectedNum:  "1",
+			expectedPrec: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -335,25 +385,25 @@ func TestDecFloatPointNumber_Div(t *testing.T) {
 func TestDecFloatPointNumber_Inv(t *testing.T) {
 	tests := []struct {
 		name         string
-		number       *DecFloatPointNumber
+		n            *DecFloatPointNumber
 		expectedNum  string
 		expectedPrec uint8
 	}{
 		{
 			name:         "106",
-			number:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(106), p: 0}},
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(106), p: 0}},
 			expectedNum:  "0.0094339622641509",
 			expectedPrec: 16,
 		},
 		{
 			name:         "106.25",
-			number:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), p: 2}},
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(10625), p: 2}},
 			expectedNum:  "0.009411764705882353",
 			expectedPrec: 18,
 		},
 		{
 			name:         "large precision",
-			number:       &DecFloatPointNumber{x: &DecFixedPointNumber{x: new(big.Int).Add(pow10(255), big.NewInt(1)), p: 255}},
+			n:            &DecFloatPointNumber{x: &DecFixedPointNumber{x: new(big.Int).Add(pow10(MaxDecPointPrecision), big.NewInt(1)), p: MaxDecPointPrecision}},
 			expectedNum:  "0." + strings.Repeat("9", 255),
 			expectedPrec: 255,
 		},
@@ -361,7 +411,7 @@ func TestDecFloatPointNumber_Inv(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.number.Inv()
+			result := tt.n.Inv()
 			assert.Equal(t, tt.expectedNum, result.String())
 			assert.Equal(t, tt.expectedPrec, result.Prec())
 		})

--- a/pkg/util/bn/float.go
+++ b/pkg/util/bn/float.go
@@ -133,31 +133,23 @@ func (x *FloatNumber) Sign() int {
 }
 
 // Add adds y to the number and returns the result.
-//
-// The y argument can be any of the types accepted by Float.
-func (x *FloatNumber) Add(y any) *FloatNumber {
-	return &FloatNumber{x: new(big.Float).Add(x.x, Float(y).x)}
+func (x *FloatNumber) Add(y *FloatNumber) *FloatNumber {
+	return &FloatNumber{x: new(big.Float).Add(x.x, y.x)}
 }
 
 // Sub subtracts y from the number and returns the result.
-//
-// The y argument can be any of the types accepted by Float.
-func (x *FloatNumber) Sub(y any) *FloatNumber {
-	return &FloatNumber{x: new(big.Float).Sub(x.x, Float(y).x)}
+func (x *FloatNumber) Sub(y *FloatNumber) *FloatNumber {
+	return &FloatNumber{x: new(big.Float).Sub(x.x, y.x)}
 }
 
 // Mul multiplies the number by y and returns the result.
-//
-// The y argument can be any of the types accepted by Float.
-func (x *FloatNumber) Mul(y any) *FloatNumber {
-	return &FloatNumber{x: new(big.Float).Mul(x.x, Float(y).x)}
+func (x *FloatNumber) Mul(y *FloatNumber) *FloatNumber {
+	return &FloatNumber{x: new(big.Float).Mul(x.x, y.x)}
 }
 
 // Div divides the number by y and returns the result.
-//
-// The y argument can be any of the types accepted by Float.
-func (x *FloatNumber) Div(y any) *FloatNumber {
-	return &FloatNumber{x: new(big.Float).Quo(x.x, Float(y).x)}
+func (x *FloatNumber) Div(y *FloatNumber) *FloatNumber {
+	return &FloatNumber{x: new(big.Float).Quo(x.x, y.x)}
 }
 
 // Sqrt returns the square root of the number.
@@ -170,10 +162,8 @@ func (x *FloatNumber) Sqrt() *FloatNumber {
 //	-1 if x <  0
 //	 0 if x == 0
 //	+1 if x >  0
-//
-// The y argument can be any of the types accepted by Float.
-func (x *FloatNumber) Cmp(y any) int {
-	return x.x.Cmp(Float(y).x)
+func (x *FloatNumber) Cmp(y *FloatNumber) int {
+	return x.x.Cmp(y.x)
 }
 
 // Abs returns the absolute number of x.

--- a/pkg/util/bn/float.go
+++ b/pkg/util/bn/float.go
@@ -1,3 +1,18 @@
+//  Copyright (C) 2021-2023 Chronicle Labs, Inc.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package bn
 
 import (
@@ -7,30 +22,36 @@ import (
 // Float returns the FloatNumber representation of x.
 //
 // The argument x can be one of the following types:
-//   - IntNumber
-//   - FloatNumber
-//   - big.Int
-//   - big.Float
-//   - int, int8, int16, int32, int64
-//   - uint, uint8, uint16, uint32, uint64
-//   - float32, float64
-//   - string - a string accepted by big.Float.SetString, otherwise it returns nil
+// - IntNumber
+// - FloatNumber
+// - DecFixedPointNumber
+// - DecFloatPointNumber
+// - big.Int
+// - big.Float
+// - int, int8, int16, int32, int64
+// - uint, uint8, uint16, uint32, uint64
+// - float32, float64
+// - string - a string accepted by big.Float.SetString, otherwise it returns nil
 //
 // If the input value is not one of the supported types, nil is returned.
 func Float(x any) *FloatNumber {
 	switch x := x.(type) {
 	case IntNumber:
-		return convertIntNumberToFloat(&x)
+		return convertIntToFloat(&x)
 	case FloatNumber:
 		return &x
 	case *IntNumber:
-		return convertIntNumberToFloat(x)
+		return convertIntToFloat(x)
 	case *FloatNumber:
 		return x
 	case DecFixedPointNumber:
 		return convertDecFixedPointToFloat(&x)
 	case *DecFixedPointNumber:
 		return convertDecFixedPointToFloat(x)
+	case DecFloatPointNumber:
+		return convertDecFloatPointToFloat(&x)
+	case *DecFloatPointNumber:
+		return convertDecFloatPointToFloat(x)
 	case *big.Int:
 		return convertBigIntToFloat(x)
 	case *big.Float:
@@ -53,115 +74,124 @@ type FloatNumber struct {
 }
 
 // Int returns the IntNumber representation of the Float.
-// The fractional part is discarded.
-func (f *FloatNumber) Int() *IntNumber {
-	return &IntNumber{x: f.BigInt()}
+//
+// The fractional part is discarded and the number is rounded.
+func (x *FloatNumber) Int() *IntNumber {
+	return convertFloatToInt(x)
 }
 
 // DecFixedPoint returns the DecFixedPointNumber representation of the Float.
-func (f *FloatNumber) DecFixedPoint(n uint8) *DecFixedPointNumber {
-	i, _ := new(big.Float).Mul(f.x, new(big.Float).SetInt(decFixedPointScale(n))).Int(nil)
-	return &DecFixedPointNumber{x: i, n: n}
+func (x *FloatNumber) DecFixedPoint(n uint8) *DecFixedPointNumber {
+	return convertFloatToDecFixedPoint(x, n)
 }
 
 // BigInt returns the *big.Int representation of the Float.
-// The fractional part is discarded.
-func (f *FloatNumber) BigInt() *big.Int {
-	bi, _ := f.x.Int(nil)
-	return bi
+//
+// The fractional part is discarded and the number is rounded.
+func (x *FloatNumber) BigInt() *big.Int {
+	return bigFloatToBigInt(x.x)
 }
 
 // BigFloat returns the *big.Float representation of the Float.
-func (f *FloatNumber) BigFloat() *big.Float {
-	return new(big.Float).Set(f.x)
-}
-
-// Float64 returns the float64 representation of the Float.
-func (f *FloatNumber) Float64() float64 {
-	f64, _ := f.x.Float64()
-	return f64
+func (x *FloatNumber) BigFloat() *big.Float {
+	return new(big.Float).Set(x.x)
 }
 
 // String returns the 10-base string representation of the Float.
-func (f *FloatNumber) String() string {
-	return f.x.String()
+func (x *FloatNumber) String() string {
+	return x.x.String()
 }
 
 // Text returns the string representation of the Float.
 // The format and prec arguments are the same as in big.Float.Text.
-func (f *FloatNumber) Text(format byte, prec int) string {
-	return f.x.Text(format, prec)
+func (x *FloatNumber) Text(format byte, prec int) string {
+	return x.x.Text(format, prec)
+}
+
+// Precision returns the precision of the Float.
+//
+// It is wrapper around big.Float.Prec.
+func (x *FloatNumber) Precision() uint {
+	return x.x.Prec()
+}
+
+// SetPrecision sets the precision of the Float.
+//
+// It is wrapper around big.Float.SetPrec.
+func (x *FloatNumber) SetPrecision(prec uint) *FloatNumber {
+	x.x.SetPrec(prec)
+	return x
 }
 
 // Sign returns:
 //
-//	-1 if f <  0
-//	 0 if f == 0
-//	+1 if f >  0
-func (f *FloatNumber) Sign() int {
-	return f.x.Sign()
+//	-1 if x <  0
+//	 0 if x == 0
+//	+1 if x >  0
+func (x *FloatNumber) Sign() int {
+	return x.x.Sign()
 }
 
-// Add adds x to the number and returns the result.
+// Add adds y to the number and returns the result.
 //
-// The x argument can be any of the types accepted by Float.
-func (f *FloatNumber) Add(x any) *FloatNumber {
-	return &FloatNumber{x: new(big.Float).Add(f.x, Float(x).x)}
+// The y argument can be any of the types accepted by Float.
+func (x *FloatNumber) Add(y any) *FloatNumber {
+	return &FloatNumber{x: new(big.Float).Add(x.x, Float(y).x)}
 }
 
-// Sub subtracts x from the number and returns the result.
+// Sub subtracts y from the number and returns the result.
 //
-// The x argument can be any of the types accepted by Float.
-func (f *FloatNumber) Sub(x any) *FloatNumber {
-	return &FloatNumber{x: new(big.Float).Sub(f.x, Float(x).x)}
+// The y argument can be any of the types accepted by Float.
+func (x *FloatNumber) Sub(y any) *FloatNumber {
+	return &FloatNumber{x: new(big.Float).Sub(x.x, Float(y).x)}
 }
 
-// Mul multiplies the number by x and returns the result.
+// Mul multiplies the number by y and returns the result.
 //
-// The x argument can be any of the types accepted by Float.
-func (f *FloatNumber) Mul(x any) *FloatNumber {
-	return &FloatNumber{x: new(big.Float).Mul(f.x, Float(x).x)}
+// The y argument can be any of the types accepted by Float.
+func (x *FloatNumber) Mul(y any) *FloatNumber {
+	return &FloatNumber{x: new(big.Float).Mul(x.x, Float(y).x)}
 }
 
-// Div divides the number by x and returns the result.
+// Div divides the number by y and returns the result.
 //
-// The x argument can be any of the types accepted by Float.
-func (f *FloatNumber) Div(x any) *FloatNumber {
-	return &FloatNumber{x: new(big.Float).Quo(f.x, Float(x).x)}
+// The y argument can be any of the types accepted by Float.
+func (x *FloatNumber) Div(y any) *FloatNumber {
+	return &FloatNumber{x: new(big.Float).Quo(x.x, Float(y).x)}
 }
 
 // Sqrt returns the square root of the number.
-func (f *FloatNumber) Sqrt() *FloatNumber {
-	return &FloatNumber{x: new(big.Float).Sqrt(f.x)}
+func (x *FloatNumber) Sqrt() *FloatNumber {
+	return &FloatNumber{x: new(big.Float).Sqrt(x.x)}
 }
 
-// Cmp compares the number with x and returns:
+// Cmp compares the number to y and returns:
 //
-//	-1 if x <  y
-//	 0 if x == y (incl. -0 == 0, -Inf == -Inf, and +Inf == +Inf)
-//	+1 if x >  y
+//	-1 if x <  0
+//	 0 if x == 0
+//	+1 if x >  0
 //
-// The x argument can be any of the types accepted by Float.
-func (f *FloatNumber) Cmp(x any) int {
-	return f.x.Cmp(Float(x).x)
+// The y argument can be any of the types accepted by Float.
+func (x *FloatNumber) Cmp(y any) int {
+	return x.x.Cmp(Float(y).x)
 }
 
-// Abs returns the absolute value of the number.
-func (f *FloatNumber) Abs() *FloatNumber {
-	return &FloatNumber{x: new(big.Float).Abs(f.x)}
+// Abs returns the absolute number of x.
+func (x *FloatNumber) Abs() *FloatNumber {
+	return &FloatNumber{x: new(big.Float).Abs(x.x)}
 }
 
-// Neg returns the negative value of the number.
-func (f *FloatNumber) Neg() *FloatNumber {
-	return &FloatNumber{x: new(big.Float).Neg(f.x)}
+// Neg returns the negative number of x.
+func (x *FloatNumber) Neg() *FloatNumber {
+	return &FloatNumber{x: new(big.Float).Neg(x.x)}
 }
 
-// Inv returns the inverse value of the number.
-func (f *FloatNumber) Inv() *FloatNumber {
-	return (&FloatNumber{x: floatOne}).Div(f)
+// Inv returns the inverse number of x.
+func (x *FloatNumber) Inv() *FloatNumber {
+	return (&FloatNumber{x: floatOne}).Div(x)
 }
 
 // IsInf reports whether the number is an infinity.
-func (f *FloatNumber) IsInf() bool {
-	return f.x.IsInf()
+func (x *FloatNumber) IsInf() bool {
+	return x.x.IsInf()
 }

--- a/pkg/util/bn/float_test.go
+++ b/pkg/util/bn/float_test.go
@@ -51,22 +51,22 @@ func TestFloat(t *testing.T) {
 		},
 		{
 			name:     "DecFixedPointNumber",
-			input:    DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			input:    DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 			expected: &FloatNumber{x: big.NewFloat(42.5)},
 		},
 		{
 			name:     "*DecFixedPointNumber",
-			input:    &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			input:    &DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 			expected: &FloatNumber{x: big.NewFloat(42.5)},
 		},
 		{
 			name:     "DecFloatPointNumber",
-			input:    DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+			input:    DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), p: 2}},
 			expected: &FloatNumber{x: big.NewFloat(42.5)},
 		},
 		{
 			name:     "*DecFloatPointNumber",
-			input:    &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+			input:    &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), p: 2}},
 			expected: &FloatNumber{x: big.NewFloat(42.5)},
 		},
 		{
@@ -157,25 +157,25 @@ func TestFloatNumber_Sign(t *testing.T) {
 
 func TestFloatNumber_Add(t *testing.T) {
 	f := Float(3.14)
-	res := f.Add(1.86)
+	res := f.Add(Float(1.86))
 	assert.Equal(t, Float(5.0).String(), res.String())
 }
 
 func TestFloatNumber_Sub(t *testing.T) {
 	f := Float(3.14)
-	res := f.Sub(1.14)
+	res := f.Sub(Float(1.14))
 	assert.Equal(t, Float(2.0).String(), res.String())
 }
 
 func TestFloatNumber_Mul(t *testing.T) {
 	f := Float(3.14)
-	res := f.Mul(2)
+	res := f.Mul(Float(2))
 	assert.Equal(t, Float(6.28).String(), res.String())
 }
 
 func TestFloatNumber_Div(t *testing.T) {
 	f := Float(3.14)
-	res := f.Div(2)
+	res := f.Div(Float(2))
 	assert.Equal(t, Float(1.57).String(), res.String())
 }
 

--- a/pkg/util/bn/float_test.go
+++ b/pkg/util/bn/float_test.go
@@ -1,3 +1,18 @@
+//  Copyright (C) 2021-2023 Chronicle Labs, Inc.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package bn
 
 import (
@@ -16,12 +31,42 @@ func TestFloat(t *testing.T) {
 	}{
 		{
 			name:     "IntNumber",
-			input:    Int(big.NewInt(42)),
+			input:    IntNumber{big.NewInt(42)},
+			expected: &FloatNumber{x: big.NewFloat(42)},
+		},
+		{
+			name:     "*IntNumber",
+			input:    &IntNumber{big.NewInt(42)},
 			expected: &FloatNumber{x: big.NewFloat(42)},
 		},
 		{
 			name:     "FloatNumber",
-			input:    Float(big.NewFloat(42.5)),
+			input:    FloatNumber{x: big.NewFloat(42.5)},
+			expected: &FloatNumber{x: big.NewFloat(42.5)},
+		},
+		{
+			name:     "*FloatNumber",
+			input:    &FloatNumber{x: big.NewFloat(42.5)},
+			expected: &FloatNumber{x: big.NewFloat(42.5)},
+		},
+		{
+			name:     "DecFixedPointNumber",
+			input:    DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &FloatNumber{x: big.NewFloat(42.5)},
+		},
+		{
+			name:     "*DecFixedPointNumber",
+			input:    &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &FloatNumber{x: big.NewFloat(42.5)},
+		},
+		{
+			name:     "DecFloatPointNumber",
+			input:    DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
+			expected: &FloatNumber{x: big.NewFloat(42.5)},
+		},
+		{
+			name:     "*DecFloatPointNumber",
+			input:    &DecFloatPointNumber{x: &DecFixedPointNumber{x: big.NewInt(4250), prec: 2}},
 			expected: &FloatNumber{x: big.NewFloat(42.5)},
 		},
 		{
@@ -40,7 +85,7 @@ func TestFloat(t *testing.T) {
 			expected: &FloatNumber{x: big.NewFloat(42)},
 		},
 		{
-			name:     "float64",
+			name:     "float",
 			input:    42.5,
 			expected: &FloatNumber{x: big.NewFloat(42.5)},
 		},
@@ -97,12 +142,6 @@ func TestFloatNumber_BigFloat(t *testing.T) {
 	bf := f.BigFloat()
 	assert.IsType(t, (*big.Float)(nil), bf)
 	assert.Equal(t, f.x, bf)
-}
-
-func TestFloatNumber_Float64(t *testing.T) {
-	f := Float(3.14)
-	f64 := f.Float64()
-	assert.Equal(t, 3.14, f64)
 }
 
 func TestFloatNumber_Sign(t *testing.T) {

--- a/pkg/util/bn/int.go
+++ b/pkg/util/bn/int.go
@@ -121,56 +121,41 @@ func (x *IntNumber) Sign() int {
 }
 
 // Add adds y to the number and returns the result.
-//
-// The y argument can be any of the types accepted by Int.
-func (x *IntNumber) Add(y any) *IntNumber {
-	return &IntNumber{x: new(big.Int).Add(x.x, Int(y).x)}
+func (x *IntNumber) Add(y *IntNumber) *IntNumber {
+	return &IntNumber{x: new(big.Int).Add(x.x, y.x)}
 }
 
 // Sub subtracts y from the number and returns the result.
-//
-// The y argument can be any of the types accepted by Int.
-func (x *IntNumber) Sub(y any) *IntNumber {
-	return &IntNumber{x: new(big.Int).Sub(x.x, Int(y).x)}
+func (x *IntNumber) Sub(y *IntNumber) *IntNumber {
+	return &IntNumber{x: new(big.Int).Sub(x.x, y.x)}
 }
 
 // Mul multiplies the number by y and returns the result.
-//
-// The y argument can be any of the types accepted by Int.
-func (x *IntNumber) Mul(y any) *IntNumber {
-	return &IntNumber{x: new(big.Int).Mul(x.x, Int(y).x)}
+func (x *IntNumber) Mul(y *IntNumber) *IntNumber {
+	return &IntNumber{x: new(big.Int).Mul(x.x, y.x)}
 }
 
 // Div divides the number by y and returns the result.
-//
-// The y argument can be any of the types accepted by Int.
-func (x *IntNumber) Div(y any) *IntNumber {
-	return &IntNumber{x: new(big.Int).Div(x.x, Int(y).x)}
+func (x *IntNumber) Div(y *IntNumber) *IntNumber {
+	return &IntNumber{x: new(big.Int).Div(x.x, y.x)}
 }
 
 // DivRoundUp divides the number by y and returns the result rounded up.
-//
-// The y argument can be any of the types accepted by Int.
-func (x *IntNumber) DivRoundUp(y any) *IntNumber {
-	bi := Int(y)
-	if new(big.Int).Rem(x.x, bi.x).Sign() > 0 {
-		return &IntNumber{x: new(big.Int).Add(new(big.Int).Div(x.x, bi.x), intOne)}
+func (x *IntNumber) DivRoundUp(y *IntNumber) *IntNumber {
+	if new(big.Int).Rem(x.x, y.x).Sign() > 0 {
+		return &IntNumber{x: new(big.Int).Add(new(big.Int).Div(x.x, y.x), intOne)}
 	}
-	return &IntNumber{x: new(big.Int).Div(x.x, bi.x)}
+	return &IntNumber{x: new(big.Int).Div(x.x, y.x)}
 }
 
 // Rem returns the remainder of the division of the number by y.
-//
-// The y argument can be any of the types accepted by Int.
-func (x *IntNumber) Rem(y any) *IntNumber {
-	return &IntNumber{x: new(big.Int).Rem(x.x, Int(y).x)}
+func (x *IntNumber) Rem(y *IntNumber) *IntNumber {
+	return &IntNumber{x: new(big.Int).Rem(x.x, y.x)}
 }
 
 // Pow returns the number raised to the power of y.
-//
-// The x argument can be any of the types accepted by Int.
-func (x *IntNumber) Pow(y any) *IntNumber {
-	return &IntNumber{x: new(big.Int).Exp(x.x, Int(y).x, nil)}
+func (x *IntNumber) Pow(y *IntNumber) *IntNumber {
+	return &IntNumber{x: new(big.Int).Exp(x.x, y.x, nil)}
 }
 
 // Sqrt returns the square root of the number.
@@ -183,10 +168,8 @@ func (x *IntNumber) Sqrt() *IntNumber {
 //	-1 if x <  0
 //	 0 if x == 0
 //	+1 if x >  0
-//
-// The y argument can be any of the types accepted by Int.
-func (x *IntNumber) Cmp(y any) int {
-	return x.x.Cmp(Int(y).x)
+func (x *IntNumber) Cmp(y *IntNumber) int {
+	return x.x.Cmp(y.x)
 }
 
 // Lsh returns the number shifted left by n bits.

--- a/pkg/util/bn/int.go
+++ b/pkg/util/bn/int.go
@@ -1,3 +1,18 @@
+//  Copyright (C) 2021-2023 Chronicle Labs, Inc.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package bn
 
 import (
@@ -7,15 +22,17 @@ import (
 // Int returns the IntNumber representation of x.
 //
 // The argument x can be one of the following types:
-//   - IntNumber
-//   - FloatNumber - the fractional part is discarded
-//   - big.Int
-//   - big.Float - the fractional part is discarded
-//   - int, int8, int16, int32, int64
-//   - uint, uint8, uint16, uint32, uint64
-//   - float32, float64 - the fractional part is discarded
-//   - string - a string accepted by big.Int.SetString, otherwise it returns nil
-//   - []byte - big-endian representation of the integer
+// - IntNumber
+// - FloatNumber
+// - DecFixedPointNumber
+// - DecFloatPointNumber
+// - big.Int
+// - big.Float
+// - int, int8, int16, int32, int64
+// - uint, uint8, uint16, uint32, uint64
+// - float32, float64
+// - string - a string accepted by big.Int.SetString, otherwise it returns nil
+// - []byte - a byte slice accepted by big.Int.SetBytes, otherwise it returns nil
 //
 // If the input value is not one of the supported types, nil is returned.
 func Int(x any) *IntNumber {
@@ -25,13 +42,17 @@ func Int(x any) *IntNumber {
 	case *IntNumber:
 		return x
 	case FloatNumber:
-		return convertFloatNumberToInt(&x)
+		return convertFloatToInt(&x)
 	case *FloatNumber:
-		return convertFloatNumberToInt(x)
+		return convertFloatToInt(x)
 	case DecFixedPointNumber:
 		return convertDecFixedPointToInt(&x)
 	case *DecFixedPointNumber:
 		return convertDecFixedPointToInt(x)
+	case DecFloatPointNumber:
+		return convertDecFloatPointToInt(&x)
+	case *DecFloatPointNumber:
+		return convertDecFloatPointToInt(x)
 	case *big.Int:
 		return convertBigIntToInt(x)
 	case *big.Float:
@@ -56,42 +77,38 @@ type IntNumber struct {
 }
 
 // Float returns the Float representation of the Int.
-func (i *IntNumber) Float() *FloatNumber {
-	return &FloatNumber{x: new(big.Float).SetInt(i.x)}
+func (x *IntNumber) Float() *FloatNumber {
+	return convertIntToFloat(x)
 }
 
-func (i *IntNumber) DecFixedPoint(n uint8) *DecFixedPointNumber {
-	return &DecFixedPointNumber{x: new(big.Int).Mul(i.x, decFixedPointScale(n)), n: n}
+// DecFixedPoint returns the DecFixedPoint representation of the Int.
+func (x *IntNumber) DecFixedPoint(n uint8) *DecFixedPointNumber {
+	return convertIntToDecFixedPoint(x, n)
+}
+
+// DecFloatPoint returns the DecFloatPoint representation of the Int.
+func (x *IntNumber) DecFloatPoint() *DecFloatPointNumber {
+	return convertIntToDecFloatPoint(x)
 }
 
 // BigInt returns the *big.Int representation of the Int.
-func (i *IntNumber) BigInt() *big.Int {
-	return new(big.Int).Set(i.x)
+func (x *IntNumber) BigInt() *big.Int {
+	return new(big.Int).Set(x.x)
 }
 
 // BigFloat returns the *big.Float representation of the Int.
-func (i *IntNumber) BigFloat() *big.Float {
-	return new(big.Float).SetInt(i.x)
-}
-
-// Int64 returns the int64 representation of the Int.
-func (i *IntNumber) Int64() int64 {
-	return i.x.Int64()
-}
-
-// Uint64 returns the uint64 representation of the Int.
-func (i *IntNumber) Uint64() uint64 {
-	return i.x.Uint64()
+func (x *IntNumber) BigFloat() *big.Float {
+	return new(big.Float).SetInt(x.x)
 }
 
 // String returns the 10-base string representation of the Int.
-func (i *IntNumber) String() string {
-	return i.x.String()
+func (x *IntNumber) String() string {
+	return x.x.String()
 }
 
 // Text returns the string representation of the Int in the given base.
-func (i *IntNumber) Text(base int) string {
-	return i.x.Text(base)
+func (x *IntNumber) Text(base int) string {
+	return x.x.Text(base)
 }
 
 // Sign returns:
@@ -99,95 +116,95 @@ func (i *IntNumber) Text(base int) string {
 //	-1 if i <  0
 //	 0 if i == 0
 //	+1 if i >  0
-func (i *IntNumber) Sign() int {
-	return i.x.Sign()
+func (x *IntNumber) Sign() int {
+	return x.x.Sign()
 }
 
-// Add adds x to the number and returns the result.
+// Add adds y to the number and returns the result.
 //
-// The x argument can be any of the types accepted by Int.
-func (i *IntNumber) Add(x any) *IntNumber {
-	return &IntNumber{x: new(big.Int).Add(i.x, Int(x).x)}
+// The y argument can be any of the types accepted by Int.
+func (x *IntNumber) Add(y any) *IntNumber {
+	return &IntNumber{x: new(big.Int).Add(x.x, Int(y).x)}
 }
 
-// Sub subtracts x from the number and returns the result.
+// Sub subtracts y from the number and returns the result.
 //
-// The x argument can be any of the types accepted by Int.
-func (i *IntNumber) Sub(x any) *IntNumber {
-	return &IntNumber{x: new(big.Int).Sub(i.x, Int(x).x)}
+// The y argument can be any of the types accepted by Int.
+func (x *IntNumber) Sub(y any) *IntNumber {
+	return &IntNumber{x: new(big.Int).Sub(x.x, Int(y).x)}
 }
 
-// Mul multiplies the number by x and returns the result.
+// Mul multiplies the number by y and returns the result.
 //
-// The x argument can be any of the types accepted by Int.
-func (i *IntNumber) Mul(x any) *IntNumber {
-	return &IntNumber{x: new(big.Int).Mul(i.x, Int(x).x)}
+// The y argument can be any of the types accepted by Int.
+func (x *IntNumber) Mul(y any) *IntNumber {
+	return &IntNumber{x: new(big.Int).Mul(x.x, Int(y).x)}
 }
 
-// Div divides the number by x and returns the result.
+// Div divides the number by y and returns the result.
 //
-// The x argument can be any of the types accepted by Int.
-func (i *IntNumber) Div(x any) *IntNumber {
-	return &IntNumber{x: new(big.Int).Div(i.x, Int(x).x)}
+// The y argument can be any of the types accepted by Int.
+func (x *IntNumber) Div(y any) *IntNumber {
+	return &IntNumber{x: new(big.Int).Div(x.x, Int(y).x)}
 }
 
-// DivRoundUp divides the number by x and returns the result rounded up.
+// DivRoundUp divides the number by y and returns the result rounded up.
 //
-// The x argument can be any of the types accepted by Int.
-func (i *IntNumber) DivRoundUp(x any) *IntNumber {
-	bi := Int(x)
-	if new(big.Int).Rem(i.x, bi.x).Sign() > 0 {
-		return &IntNumber{x: new(big.Int).Add(new(big.Int).Div(i.x, bi.x), intOne)}
+// The y argument can be any of the types accepted by Int.
+func (x *IntNumber) DivRoundUp(y any) *IntNumber {
+	bi := Int(y)
+	if new(big.Int).Rem(x.x, bi.x).Sign() > 0 {
+		return &IntNumber{x: new(big.Int).Add(new(big.Int).Div(x.x, bi.x), intOne)}
 	}
-	return &IntNumber{x: new(big.Int).Div(i.x, bi.x)}
+	return &IntNumber{x: new(big.Int).Div(x.x, bi.x)}
 }
 
-// Rem returns the remainder of the division of the number by x.
+// Rem returns the remainder of the division of the number by y.
 //
-// The x argument can be any of the types accepted by Int.
-func (i *IntNumber) Rem(x any) *IntNumber {
-	return &IntNumber{x: new(big.Int).Rem(i.x, Int(x).x)}
+// The y argument can be any of the types accepted by Int.
+func (x *IntNumber) Rem(y any) *IntNumber {
+	return &IntNumber{x: new(big.Int).Rem(x.x, Int(y).x)}
 }
 
-// Pow returns the number raised to the power of x.
+// Pow returns the number raised to the power of y.
 //
 // The x argument can be any of the types accepted by Int.
-func (i *IntNumber) Pow(x any) *IntNumber {
-	return &IntNumber{x: new(big.Int).Exp(i.x, Int(x).x, nil)}
+func (x *IntNumber) Pow(y any) *IntNumber {
+	return &IntNumber{x: new(big.Int).Exp(x.x, Int(y).x, nil)}
 }
 
 // Sqrt returns the square root of the number.
-func (i *IntNumber) Sqrt() *IntNumber {
-	return &IntNumber{x: new(big.Int).Sqrt(i.x)}
+func (x *IntNumber) Sqrt() *IntNumber {
+	return &IntNumber{x: new(big.Int).Sqrt(x.x)}
 }
 
-// Cmp compares the number to x and returns:
+// Cmp compares the number to y and returns:
 //
-//	-1 if i <  x
-//	 0 if i == x
-//	+1 if i >  x
+//	-1 if x <  0
+//	 0 if x == 0
+//	+1 if x >  0
 //
-// The x argument can be any of the types accepted by Int.
-func (i *IntNumber) Cmp(x any) int {
-	return i.x.Cmp(Int(x).x)
+// The y argument can be any of the types accepted by Int.
+func (x *IntNumber) Cmp(y any) int {
+	return x.x.Cmp(Int(y).x)
 }
 
 // Lsh returns the number shifted left by n bits.
-func (i *IntNumber) Lsh(n uint) *IntNumber {
-	return &IntNumber{x: new(big.Int).Lsh(i.x, n)}
+func (x *IntNumber) Lsh(n uint) *IntNumber {
+	return &IntNumber{x: new(big.Int).Lsh(x.x, n)}
 }
 
 // Rsh returns the number shifted right by n bits.
-func (i *IntNumber) Rsh(n uint) *IntNumber {
-	return &IntNumber{x: new(big.Int).Rsh(i.x, n)}
+func (x *IntNumber) Rsh(n uint) *IntNumber {
+	return &IntNumber{x: new(big.Int).Rsh(x.x, n)}
 }
 
-// Abs returns the absolute number.
-func (i *IntNumber) Abs() *IntNumber {
-	return &IntNumber{x: new(big.Int).Abs(i.x)}
+// Abs returns the absolute number of x.
+func (x *IntNumber) Abs() *IntNumber {
+	return &IntNumber{x: new(big.Int).Abs(x.x)}
 }
 
-// Neg returns the negative number.
-func (i *IntNumber) Neg() *IntNumber {
-	return &IntNumber{x: new(big.Int).Neg(i.x)}
+// Neg returns the negative number of x.
+func (x *IntNumber) Neg() *IntNumber {
+	return &IntNumber{x: new(big.Int).Neg(x.x)}
 }

--- a/pkg/util/bn/int_test.go
+++ b/pkg/util/bn/int_test.go
@@ -1,3 +1,18 @@
+//  Copyright (C) 2021-2023 Chronicle Labs, Inc.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package bn
 
 import (
@@ -15,13 +30,43 @@ func TestInt(t *testing.T) {
 	}{
 		{
 			name:     "IntNumber",
-			input:    Int(big.NewInt(42)),
+			input:    IntNumber{big.NewInt(42)},
+			expected: &IntNumber{x: big.NewInt(42)},
+		},
+		{
+			name:     "*IntNumber",
+			input:    &IntNumber{big.NewInt(42)},
 			expected: &IntNumber{x: big.NewInt(42)},
 		},
 		{
 			name:     "FloatNumber",
-			input:    Float(big.NewFloat(42.5)),
-			expected: &IntNumber{x: big.NewInt(42)},
+			input:    &FloatNumber{x: big.NewFloat(42.5)},
+			expected: &IntNumber{x: big.NewInt(43)},
+		},
+		{
+			name:     "*FloatNumber",
+			input:    &FloatNumber{x: big.NewFloat(42.5)},
+			expected: &IntNumber{x: big.NewInt(43)},
+		},
+		{
+			name:     "DecFixedPointNumber",
+			input:    DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &IntNumber{x: big.NewInt(43)},
+		},
+		{
+			name:     "*DecFixedPointNumber",
+			input:    &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &IntNumber{x: big.NewInt(43)},
+		},
+		{
+			name:     "DecFixedPointNumber",
+			input:    DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &IntNumber{x: big.NewInt(43)},
+		},
+		{
+			name:     "*DecFixedPointNumber",
+			input:    &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			expected: &IntNumber{x: big.NewInt(43)},
 		},
 		{
 			name:     "big.Int",
@@ -31,7 +76,7 @@ func TestInt(t *testing.T) {
 		{
 			name:     "big.Float",
 			input:    big.NewFloat(42.5),
-			expected: &IntNumber{x: big.NewInt(42)},
+			expected: &IntNumber{x: big.NewInt(43)},
 		},
 		{
 			name:     "int",
@@ -39,9 +84,9 @@ func TestInt(t *testing.T) {
 			expected: &IntNumber{x: big.NewInt(42)},
 		},
 		{
-			name:     "float64",
+			name:     "float",
 			input:    42.5,
-			expected: &IntNumber{x: big.NewInt(42)},
+			expected: &IntNumber{x: big.NewInt(43)},
 		},
 		{
 			name:     "string",
@@ -94,16 +139,6 @@ func TestIntNumber_BigInt(t *testing.T) {
 	bi := i.BigInt()
 	assert.IsType(t, (*big.Int)(nil), bi)
 	assert.Equal(t, big.NewInt(123), bi)
-}
-
-func TestIntNumber_Int64(t *testing.T) {
-	i := Int(123)
-	assert.Equal(t, int64(123), i.Int64())
-}
-
-func TestIntNumber_Uint64(t *testing.T) {
-	i := Int(uint64(123))
-	assert.Equal(t, uint64(123), i.Uint64())
 }
 
 func TestIntNumber_BigFloat(t *testing.T) {

--- a/pkg/util/bn/int_test.go
+++ b/pkg/util/bn/int_test.go
@@ -50,22 +50,22 @@ func TestInt(t *testing.T) {
 		},
 		{
 			name:     "DecFixedPointNumber",
-			input:    DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			input:    DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 			expected: &IntNumber{x: big.NewInt(43)},
 		},
 		{
 			name:     "*DecFixedPointNumber",
-			input:    &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			input:    &DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 			expected: &IntNumber{x: big.NewInt(43)},
 		},
 		{
 			name:     "DecFixedPointNumber",
-			input:    DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			input:    DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 			expected: &IntNumber{x: big.NewInt(43)},
 		},
 		{
 			name:     "*DecFixedPointNumber",
-			input:    &DecFixedPointNumber{x: big.NewInt(4250), prec: 2},
+			input:    &DecFixedPointNumber{x: big.NewInt(4250), p: 2},
 			expected: &IntNumber{x: big.NewInt(43)},
 		},
 		{
@@ -161,43 +161,43 @@ func TestIntNumber_Sign(t *testing.T) {
 
 func TestIntNumber_Add(t *testing.T) {
 	i := Int(123)
-	res := i.Add(456)
+	res := i.Add(Int(456))
 	assert.Equal(t, Int(579), res)
 }
 
 func TestIntNumber_Sub(t *testing.T) {
 	i := Int(123)
-	res := i.Sub(23)
+	res := i.Sub(Int(23))
 	assert.Equal(t, Int(100), res)
 }
 
 func TestIntNumber_Mul(t *testing.T) {
 	i := Int(123)
-	res := i.Mul(3)
+	res := i.Mul(Int(3))
 	assert.Equal(t, Int(369), res)
 }
 
 func TestIntNumber_Div(t *testing.T) {
 	i := Int(123)
-	res := i.Div(3)
+	res := i.Div(Int(3))
 	assert.Equal(t, Int(41), res)
 }
 
 func TestIntNumber_DivRoundUp(t *testing.T) {
 	i := Int(123)
-	res := i.DivRoundUp(50)
+	res := i.DivRoundUp(Int(50))
 	assert.Equal(t, Int(3), res)
 }
 
 func TestIntNumber_Rem(t *testing.T) {
 	i := Int(123)
-	res := i.Rem(50)
+	res := i.Rem(Int(50))
 	assert.Equal(t, Int(23), res)
 }
 
 func TestIntNumber_Pow(t *testing.T) {
 	i := Int(2)
-	res := i.Pow(3)
+	res := i.Pow(Int(3))
 	assert.Equal(t, Int(8), res)
 }
 


### PR DESCRIPTION
This PR replaces `bn.FloatNumber` with `bn.DecFloatPointNumber` in the `value.Tick` struct. This change eliminates the need to convert `bn.FloatNumber` to `bn.DecFloatPointNumber` during hash calculation and marshaling messages.