### PR TITLE
Enable external MultiAddr for LibP2P Transport

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -2,8 +2,12 @@ FROM golang:1.20-alpine as builder
 RUN apk --no-cache add git gcc libc-dev linux-headers
 
 WORKDIR /app
-COPY . .
-RUN go mod vendor && mkdir -p dist
+
+COPY go.mod go.sum version.go ./
+RUN go mod download -x && mkdir -p ./dist
+
+COPY cmd ./cmd
+COPY pkg ./pkg
 
 ARG APP_VERSION="0.0.0-dev.0"
 ARG APP_NAME

--- a/cmd/ghost/main_test.go
+++ b/cmd/ghost/main_test.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,7 @@ func TestConfig_Ghost_Run(t *testing.T) {
 		args     []string
 		config   supervisor.Config
 		services supervisor.Service
+		envVars  map[string]string
 		wantErr  bool
 	}{
 		{
@@ -41,10 +43,18 @@ func TestConfig_Ghost_Run(t *testing.T) {
 			args:     []string{"--config", "../../config.hcl"},
 			config:   &ghost.Config{},
 			services: &ghost.Services{},
+			envVars: map[string]string{
+				"CFG_LIBP2P_EXTERNAL_ADDR": "1.2.3.4",
+			},
 		},
 	}
 
 	for _, tt := range tests {
+		os.Clearenv()
+		for k, v := range tt.envVars {
+			require.NoError(t, os.Setenv(k, v))
+		}
+
 		t.Run(tt.name, func(t *testing.T) {
 			var ff = cmd.FilesFlags{}
 			require.NoError(t, ff.FlagSet().Parse(tt.args))

--- a/config-transport.hcl
+++ b/config-transport.hcl
@@ -23,7 +23,7 @@ transport {
       blocked_addrs      = explode(env("CFG_ITEM_SEPARATOR", "\n"), env("CFG_LIBP2P_BLOCKED_ADDRS", ""))
       disable_discovery  = tobool(env("CFG_LIBP2P_DISABLE_DISCOVERY", "0"))
       ethereum_key       = "default"
-      external_ip        = env("CFG_LIBP2P_EXTERNAL_IP", "")
+      external_addr      = env("CFG_LIBP2P_EXTERNAL_ADDR", env("CFG_LIBP2P_EXTERNAL_IP", ""))
     }
   }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,6 +62,7 @@ services:
       ### local address book
       CFG_WEBAPI_STATIC_ADDR_BOOK: ""
 
+      CFG_LIBP2P_EXTERNAL_ADDR: "/dns/www.example.com"
   _base_spectre:
     <<: *disabled
     environment: &base_spectre

--- a/pkg/config/transport/testdata/config.hcl
+++ b/pkg/config/transport/testdata/config.hcl
@@ -7,7 +7,7 @@ libp2p {
   blocked_addrs      = ["/ip4/0.0.0.0/tcp/9000"]
   disable_discovery  = true
   ethereum_key       = "key"
-  external_ip        = "10.1.2.3"
+  external_addr      = "/dns/eee.example.com"
 }
 
 webapi {

--- a/pkg/config/transport/transport_test.go
+++ b/pkg/config/transport/transport_test.go
@@ -53,7 +53,6 @@ func TestConfig(t *testing.T) {
 				assert.Equal(t, []string{"/ip4/0.0.0.0/tcp/9000"}, cfg.LibP2P.BlockedAddrs)
 				assert.Equal(t, true, cfg.LibP2P.DisableDiscovery)
 				assert.Equal(t, "key", cfg.LibP2P.EthereumKey)
-				assert.Equal(t, "10.1.2.3", cfg.LibP2P.ExternalIP.String())
 
 				// WebAPI
 				assert.Equal(t, "0x3456789012345678901234567890123456789012", cfg.WebAPI.Feeds[0].String())


### PR DESCRIPTION
Introduces `CFG_LIBP2P_EXTERNAL_ADDR` that supersedes `CFG_LIBP2P_EXTERNAL_IP` but the latter can still be used for backward compatibility.

`CFG_LIBP2P_EXTERNAL_*` can be a `MultiAddr` (`/dns/...`, `/ip4/...`, etc.)
or a classical IP4 (eg. `1.2.3.4`).

Needed for:
- https://github.com/chronicleprotocol/musig/pull/34