### PR TITLE
Do not break if didn't get the data point[sc-2987]

### DIFF
--- a/pkg/datapoint/datapoint.go
+++ b/pkg/datapoint/datapoint.go
@@ -205,11 +205,17 @@ func (p Point) MarshalTrace() ([]byte, error) {
 		meta := make(map[string]any)
 		point := node.(Point)
 		typ := "data_point"
-		meta["value"] = point.Value.Print()
+		if point.Value == nil {
+			meta["value"] = nil
+		} else {
+			meta["value"] = point.Value.Print()
+		}
 		meta["time"] = point.Time.In(time.UTC).Format(time.RFC3339Nano)
 		var points []any
-		for _, t := range point.SubPoints {
-			points = append(points, t)
+		if point.SubPoints != nil {
+			for _, t := range point.SubPoints {
+				points = append(points, t)
+			}
 		}
 		for k, v := range point.Meta {
 			if k == "type" {

--- a/pkg/datapoint/datapoint.go
+++ b/pkg/datapoint/datapoint.go
@@ -205,9 +205,7 @@ func (p Point) MarshalTrace() ([]byte, error) {
 		meta := make(map[string]any)
 		point := node.(Point)
 		typ := "data_point"
-		if point.Value == nil {
-			meta["value"] = nil
-		} else {
+		if point.Value != nil {
 			meta["value"] = point.Value.Print()
 		}
 		meta["time"] = point.Time.In(time.UTC).Format(time.RFC3339Nano)

--- a/pkg/datapoint/datapoint.go
+++ b/pkg/datapoint/datapoint.go
@@ -210,10 +210,8 @@ func (p Point) MarshalTrace() ([]byte, error) {
 		}
 		meta["time"] = point.Time.In(time.UTC).Format(time.RFC3339Nano)
 		var points []any
-		if point.SubPoints != nil {
-			for _, t := range point.SubPoints {
-				points = append(points, t)
-			}
+		for _, t := range point.SubPoints {
+			points = append(points, t)
 		}
 		for k, v := range point.Meta {
 			if k == "type" {


### PR DESCRIPTION
**Reproduce the bug**
- Now `gemini` origin is under maintenance, it makes some pairs get null of data point.
- Run `gofer data --config config.hcl --format trace`, then you can see breaking with `nil` access 