### PR TITLE
Deep Equal with filter function

### DIFF
--- a/pkg/util/reflectutil/deepequal.go
+++ b/pkg/util/reflectutil/deepequal.go
@@ -1,0 +1,129 @@
+//  Copyright (C) 2021-2023 Chronicle Labs, Inc.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package reflectutil
+
+import (
+	"reflect"
+)
+
+// FilterFunc filter out to check if two values don't need to compare
+// Return false not to compare, true to compare
+type FilterFunc func(any, any) bool
+
+// DeepEqual reports whether x and y are "deeply equal".
+// Do not test if filter function returns true for comparing two values.
+func DeepEqual(x, y any, filter FilterFunc) bool {
+	if x == nil || y == nil {
+		return x == y
+	}
+	v1 := reflect.ValueOf(x)
+	v2 := reflect.ValueOf(y)
+	if v1.Type() != v2.Type() {
+		return false
+	}
+	return deepEqual(v1, v2, filter)
+}
+
+// deepEqual tests for deep equality using reflected types recursively.
+// Do not test if filter function returns true for comparing two values.
+func deepEqual(v1, v2 reflect.Value, filter FilterFunc) bool { //nolint:gocyclo,funlen
+	if !v1.IsValid() || !v2.IsValid() {
+		return v1.IsValid() == v2.IsValid()
+	}
+	if v1.Type() != v2.Type() {
+		return false
+	}
+	if filter != nil && !filter(v1, v2) {
+		return true
+	}
+
+	switch v1.Kind() {
+	case reflect.Struct:
+		if v1.NumField() != v2.NumField() {
+			return false
+		}
+		for i := 0; i < v1.NumField(); i++ {
+			fieldStruct1 := v1.Type().Field(i)
+			fieldStruct2 := v1.Type().Field(i)
+			if filter != nil && filter(fieldStruct1, fieldStruct2) {
+				continue
+			}
+			if !deepEqual(v1.Field(i), v2.Field(i), filter) {
+				return false
+			}
+		}
+	case reflect.Pointer:
+		if v1.UnsafePointer() == v2.UnsafePointer() {
+			return true
+		}
+		return deepEqual(v1.Elem(), v2.Elem(), filter)
+	case reflect.Slice:
+		if v1.IsNil() != v2.IsNil() {
+			return false
+		}
+		if v1.Len() != v2.Len() {
+			return false
+		}
+		if v1.UnsafePointer() == v2.UnsafePointer() {
+			return true
+		}
+		for i := 0; i < v1.Len(); i++ {
+			if !deepEqual(v1.Index(i), v2.Index(i), filter) {
+				return false
+			}
+		}
+	case reflect.Map:
+		if v1.IsNil() != v2.IsNil() {
+			return false
+		}
+		if v1.Len() != v2.Len() {
+			return false
+		}
+		if v1.UnsafePointer() == v2.UnsafePointer() {
+			return true
+		}
+		if len(v1.MapKeys()) != len(v2.MapKeys()) {
+			return false
+		}
+		for _, k := range v1.MapKeys() {
+			val1 := v1.MapIndex(k)
+			val2 := v2.MapIndex(k)
+			if !deepEqual(val1, val2, filter) {
+				return false
+			}
+		}
+	case reflect.Func:
+		if v1.IsNil() && v2.IsNil() {
+			return true
+		}
+		return false
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v1.Int() == v2.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v1.Uint() == v2.Uint()
+	case reflect.String:
+		return v1.String() == v2.String()
+	case reflect.Bool:
+		return v1.Bool() == v2.Bool()
+	case reflect.Float32, reflect.Float64:
+		return v1.Float() == v2.Float()
+	case reflect.Complex64, reflect.Complex128:
+		return v1.Complex() == v2.Complex()
+	default:
+		return v1.Interface() == v2.Interface()
+	}
+	return true
+}

--- a/pkg/util/reflectutil/deepequal.go
+++ b/pkg/util/reflectutil/deepequal.go
@@ -58,7 +58,7 @@ func deepEqual(v1, v2 reflect.Value, filter FilterFunc) bool { //nolint:gocyclo,
 		for i := 0; i < v1.NumField(); i++ {
 			fieldStruct1 := v1.Type().Field(i)
 			fieldStruct2 := v1.Type().Field(i)
-			if filter != nil && filter(fieldStruct1, fieldStruct2) {
+			if filter != nil && !filter(fieldStruct1, fieldStruct2) {
 				continue
 			}
 			if !deepEqual(v1.Field(i), v2.Field(i), filter) {

--- a/pkg/util/reflectutil/deepequal_test.go
+++ b/pkg/util/reflectutil/deepequal_test.go
@@ -1,0 +1,231 @@
+package reflectutil
+
+import (
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type customByte byte
+type customBytes []byte
+type customStruct struct {
+	intS     int
+	float32S float32
+	boolS    bool
+}
+type structWithSelfPtr struct {
+	p *structWithSelfPtr
+	s string
+}
+type loop *loop
+
+var loop1, loop2 loop
+
+func filterInt(v1, v2 any) bool {
+	ref1 := v1.(reflect.Value)
+	ref2 := v2.(reflect.Value)
+	if ref1.Kind() != reflect.Int || ref2.Kind() != reflect.Int {
+		return false
+	}
+	return true
+}
+
+func filterString(v1, v2 any) bool {
+	ref1 := v1.(reflect.Value)
+	ref2 := v2.(reflect.Value)
+	if ref1.Kind() == reflect.String || ref2.Kind() == reflect.String {
+		return false
+	}
+	if ref1.Kind() == reflect.Interface && reflect.TypeOf(ref1.Interface()).Kind() == reflect.String {
+		return false
+	}
+	if ref2.Kind() == reflect.Interface && reflect.TypeOf(ref2.Interface()).Kind() == reflect.String {
+		return false
+	}
+	return true
+}
+
+func filterSlice(v1, v2 any) bool {
+	ref1 := v1.(reflect.Value)
+	ref2 := v2.(reflect.Value)
+	if ref1.Kind() != reflect.Slice || ref2.Kind() != reflect.Slice {
+		return false
+	}
+	return true
+}
+
+func filterPointer(v1, v2 any) bool {
+	ref1 := v1.(reflect.Value)
+	ref2 := v2.(reflect.Value)
+	if ref1.Kind() != reflect.Pointer || ref2.Kind() != reflect.Pointer {
+		return false
+	}
+	return true
+}
+
+func TestDeepEquals(t *testing.T) {
+	var (
+		intS  int = -3
+		intS2 int = -3
+	)
+	var intSP *int
+	var (
+		uintS  uint = 3
+		uintS2 uint = 3
+	)
+	var (
+		stringS  string = "string"
+		stringS2 string = "string"
+	)
+	var (
+		float32S  float32 = 3.141569
+		float32S2 float32 = 3.141569
+	)
+	var (
+		float64S  float64 = 3.141569
+		float64S2 float64 = 3.141569
+	)
+
+	var structS1 = customStruct{
+		intS:     3,
+		float32S: 3.141569,
+		boolS:    true,
+	}
+	var structS2 = customStruct{
+		intS:     3,
+		float32S: 3.141569,
+		boolS:    true,
+	}
+	var structS1P = &structS1
+	var structS2P = &structS2
+	var func1 = func(v1, v2 int) bool {
+		return v1 == v2
+	}
+	var func2 = func(v1, v2 int) bool {
+		return v1 == v2
+	}
+	var funcp1 func()
+	var funcp2 func()
+	var (
+		any1 any
+		any2 any
+	)
+
+	var tests = []struct {
+		name       string
+		arg1       interface{}
+		arg2       interface{}
+		filterFunc FilterFunc
+		expected   bool
+	}{
+		// Equalities
+		// primary types: same types and different types(but same value)
+		{"int to int", int32(-3), int32(-3), nil, true},
+		{"uint to uint", uint32(3), uint32(3), nil, true},
+		{"float to float", float32(3.141569), float32(3.141569), nil, true},
+		{"string to string", "string", "string", nil, true},
+		{"bool to bool", true, true, nil, true},
+		// pointers: single pointer, double pointer, function pointer, struct pointer, nil
+		{"single pointer, same address, int", &intS, &intS, nil, true},
+		{"single pointer, different address, int", &intS, &intS2, nil, true},
+		{"single pointer, same address, uint", &uintS, &uintS, nil, true},
+		{"single pointer, different address, uint", &uintS, &uintS2, nil, true},
+		{"single pointer, same address, string", &stringS, &stringS, nil, true},
+		{"single pointer, different address, string", &stringS, &stringS2, nil, true},
+		{"single pointer, same address, float32", &float32S, &float32S, nil, true},
+		{"single pointer, different address, float32", &float32S, &float32S2, nil, true},
+		{"single pointer, same address, float64", &float64S, &float64S, nil, true},
+		{"single pointer, different address, float64", &float64S, &float64S2, nil, true},
+		{"double pointer", &structS1P, &structS2P, nil, true},
+		{"nil", nil, nil, nil, true},
+		// struct
+		{"struct", structS1, structS2, nil, true},
+		{"struct pointer", &structS1, &structS2, nil, true},
+		{"struct with self pointer", &structWithSelfPtr{p: &structWithSelfPtr{s: "a"}}, &structWithSelfPtr{p: &structWithSelfPtr{s: "a"}}, nil, true},
+		// map
+		{"map", map[int]string{1: "one", 2: "two"}, map[int]string{1: "one", 2: "two"}, nil, true},
+		{"map pointer", &map[int]string{1: "one", 2: "two"}, &map[int]string{2: "two", 1: "one"}, nil, true},
+		// func
+		{"func pointer", funcp1, funcp2, nil, true},
+		// slice
+		{"slice", []byte{1, 2, 3}, []byte{1, 2, 3}, nil, true},
+		{"double slice", [][]byte{{1, 2, 3}}, [][]byte{{1, 2, 3}}, nil, true},
+		{"slice, type", []customByte{1, 2, 3}, []customByte{1, 2, 3}, nil, true},
+		{"slice, type", customBytes{1, 2, 3}, customBytes{1, 2, 3}, nil, true},
+
+		// Inequalities
+		// primary types: same types and different types(but same value)
+		{"int to int", int32(-3), int32(-4), nil, false},
+		{"uint to uint", uint32(3), uint32(4), nil, false},
+		{"float to float", float32(3.141569), float64(3.141569), nil, false},
+		{"string to string", "string", "String", nil, false},
+		{"bool to bool", true, false, nil, false},
+		{"int to uint", int(314), uint(314), nil, false},
+		{"int to string", int(314), "314", nil, false},
+		{"int to bool", 1, true, nil, false},
+		{"int to bool", 0, false, nil, false},
+		{"int to float", int(3), float32(3), nil, false},
+		// pointers
+		{"single pointer, different address, int to uint", &intS, &uintS, nil, false},
+		{"single pointer, different address, float32 to float64", &float32S, &float64S, nil, false},
+		{"single pointer, different address, *int to nil", intSP, nil, nil, false},
+		{"double pointer", &intSP, nil, nil, false},
+		// struct
+		{"struct", customStruct{1, 3.141569, false}, customStruct{1, 3.141569, true}, nil, false},
+		{"struct pointer", &customStruct{1, 3.141569, false}, &customStruct{1, 3.141569, true}, nil, false},
+		{"struct with self pointer", &structWithSelfPtr{p: &structWithSelfPtr{s: "a"}}, &structWithSelfPtr{p: &structWithSelfPtr{s: "b"}}, nil, false},
+		// map
+		{"map", map[int]string{1: "one", 2: "two"}, map[int]string{1: "One", 2: "Two"}, nil, false},
+		{"map pointer", &map[int]string{1: "one", 2: "two"}, &map[int]string{2: "Two", 1: "One"}, nil, false},
+		{"map with different type", map[int]string{1: "one", 2: "two"}, map[uint]string{1: "one", 2: "two"}, nil, false},
+		// func
+		{"function pointer", func1, func2, nil, false},
+		// slice
+		{"slice", []byte{1, 2, 3}, []byte{0, 2, 3}, nil, false},
+		{"slice, different len", []byte{1, 2, 3}, []byte{2, 3}, nil, false},
+		{"double slice", [][]byte{{1, 2, 3}}, [][]byte{{0, 2, 3}}, nil, false},
+		{"slice, same type", []customByte{1, 2, 3}, []customByte{0, 2, 3}, nil, false},
+		{"slice, same type", customBytes{1, 2, 3}, customBytes{0, 2, 3}, nil, false},
+		{"slice, different type", []customByte{1, 2, 3}, []byte{1, 2, 3}, nil, false},
+		{"slice, different type", customBytes{1, 2, 3}, []customByte{1, 2, 3}, nil, false},
+
+		// Floating points
+		{"NaN", math.NaN(), math.NaN(), nil, false},
+		{"NaN slice", []float64{math.NaN()}, []float64{math.NaN()}, nil, false},
+		{"NaN slice pointer", &[1]float64{math.NaN()}, &[1]float64{math.NaN()}, nil, false},
+
+		// Empty
+		{"empty slice", []int{}, []int{}, nil, true},
+		{"nil slice", []int(nil), []int(nil), nil, true},
+		{"nil slice and empty", []int{}, []int(nil), nil, false},
+		{"empty map", map[int]int{}, map[int]int{}, nil, true},
+		{"nil map", map[int]int(nil), map[int]int(nil), nil, true},
+		{"nil map and empty", map[int]int{}, map[int]int(nil), nil, false},
+
+		// Others
+		{"loop", &loop1, &loop2, nil, true},
+		{"any", &any1, &any2, nil, true},
+
+		// Filter func
+		{"filter, different type", 1, "one", filterInt, false},
+		{"filter, different type, reverse", "one", 1, filterInt, false},
+		{"filter slice", []byte{1, 2, 3}, []byte{0, 2, 3}, filterSlice, true},
+		{"filter map", map[int]any{1: "one", 2: "two"}, map[int]any{1: "one", 2: 2}, filterString, true},
+		{"filter pointer", &map[int]string{1: "one"}, &map[int]string{2: "one"}, filterPointer, true},
+		{"filter struct", customStruct{1, 3.141569, true}, customStruct{0, 3.141569, true}, filterInt, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.filterFunc == nil {
+				assert.Equal(t, tt.expected, reflect.DeepEqual(tt.arg1, tt.arg2))
+			}
+			assert.Equal(t, tt.expected, DeepEqual(tt.arg1, tt.arg2, tt.filterFunc))
+		})
+	}
+}
+
+func TestDeepEqualsFull(t *testing.T) {
+
+}

--- a/pkg/util/reflectutil/deepequal_test.go
+++ b/pkg/util/reflectutil/deepequal_test.go
@@ -225,7 +225,3 @@ func TestDeepEquals(t *testing.T) {
 		})
 	}
 }
-
-func TestDeepEqualsFull(t *testing.T) {
-
-}


### PR DESCRIPTION
### description of pull request:

`DeepEqual` Function to compare two variables if deeply equal or not with the filter function.

This function will be used to compare two `config` struct variables by filtering out some member fields, such as `hcl.Range`, `hcl.Body`, `hcl.BodyContent`.
i.e. compare the member variables of `hcl` tag or others.

```
type configNode struct {
	Nodes []configDynamicNode // Handled by PostDecodeBlock method.

	// HCL fields:
	Remain  hcl.Body        `hcl:",remain"`
	Range   hcl.Range       `hcl:",range"`
	Content hcl.BodyContent `hcl:",content"`
}

// configNodeOrigin is a configuration for an Origin node.
type configNodeOrigin struct {
	Origin string `hcl:"origin,label"`

	configNode

	Query              cty.Value `hcl:"query"`
	FreshnessThreshold int       `hcl:"freshness_threshold,optional"`
	ExpiryThreshold    int       `hcl:"expiry_threshold,optional"`
}
```
In the above code, will not compare `Remain`, `Range`, `Content`, even they have `hcl` tag.

#### Usecase
```
var (
  base Config,
  alternative Config
)
if reflectutil.DeepEqual(base, alternative, filterFunc) {
  return nil
}
```

```
func filterFunc(v1, v2 any) bool {
	refVal1, ok1 := v1.(reflect.Value)
	refVal2, ok2 := v2.(reflect.Value)
	if ok1 != ok2 {
		return false
	}
	if ok1 && ok2 {
		if refVal1.Type() == hclRangeTy || refVal2.Type() == hclRangeTy {
			return false
		}
		if refVal1.Type() == hclBodyTy || refVal2.Type() == hclBodyTy {
			return false
		}
		if refVal1.Type() == hclBodyContentTy || refVal2.Type() == hclBodyContentTy {
			return false
		}
	}
	refStruct1, ok1 := v1.(reflect.StructField)
	refStruct2, ok2 := v1.(reflect.StructField)
	if ok1 != ok2 {
		return false
	}
	if ok1 && ok2 {
		if _, tagged := refStruct1.Tag.Lookup("hcl"); !tagged {
			return false
		}
		if _, tagged := refStruct2.Tag.Lookup("hcl"); !tagged {
			return false
		}
	}
	return true
}
```
#### Reason why we need to redefine `DeepEqual` function
- We do want to compare only the configuration values, not other members.
- Even the exported hcl config is correct, once imported, the `hcl.Range, hcl.Body, hcl.BodyContent` those internal values are little different than original one.
- Some fields inside `Config` struct, such as [`feed *feed.Feed`](https://github.com/chronicleprotocol/oracle-suite/blob/master/pkg/config/feednext/feed.go#L54), are leading breaks app when use `reflect.DeepEqual`.
