### PR TITLE
Update Bitfinex JQ and related symbols

### DIFF
--- a/config/config-gofer.hcl
+++ b/config/config-gofer.hcl
@@ -22,8 +22,8 @@ gofer {
 
   origin "bitfinex" {
     type = "tick_generic_jq"
-    url  = "https://api-pub.bitfinex.com/v2/tickers?symbols=ALL"
-    jq   = ".[] | select(.[0] == \"t\" + ($ucbase + $ucquote) or .[0] == \"t\" + ($ucbase + \":\" + $ucquote) ) | {price: .[7], time: now|round, volume: .[8]}"
+    url  = "https://api-pub.bitfinex.com/v2/tickers?symbols=t$${ucbase}$${ucquote}"
+    jq   = "{price: .[][7], time: now|round, volume: .[][8]}"
   }
 
   origin "bitstamp" {
@@ -801,10 +801,7 @@ gofer {
       }
       origin "coinbase" { query = "XTZ/USD" }
       origin "kraken" { query = "XTZ/USD" }
-      indirect {
-        origin "bitfinex" { query = "XTZ/BTC" }
-        reference { data_model = "BTC/USD" }
-      }
+      origin "bitfinex" { query = "XTZ/USD" }
     }
   }
 


### PR DESCRIPTION

| Q                        | A
| ------------------------ | ---
| Service                  | (gofer)
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | n/a
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Tests Added + Pass?      | no
| Documentation PR         | `[skip-ci]`
| Any Dependency Changes?  | no
| License                  | AGPL

### description of pull request:

Unsure why the JQ for this query is so complex, but the bitfinex docs may have been clarified since it was first written: https://docs.bitfinex.com/reference/rest-public-tickers 

It can be simplified per this PR. You can see in the curl request below the request to bitfinex can be simplified and pulls out only the symbol information relevant to gofer's needs. 

Additionally, working through the bitfinex related queries, `XTCUSD` is now available directly via there, and doesn't need an indirect reference.

```bash
curl -s "https://api-pub.bitfinex.com/v2/tickers?symbols=tXTZUSD" | jq
[
  [
    "tXTZUSD",
    0.86748,
    69350.14351095,
    0.87071,
    60445.12864295,
    0.01085,
    0.01254248,
    0.87591,
    307498.09659568,
    0.88855,
    0.76473
  ]
]
```