### PR TITLE
Correct the strptime pattern for hitbtc

### DIFF
--- a/config/config-gofer.hcl
+++ b/config/config-gofer.hcl
@@ -76,7 +76,7 @@ gofer {
   origin "hitbtc" {
     type = "tick_generic_jq"
     url  = "https://api.hitbtc.com/api/2/public/ticker?symbols=$${ucbase}$${ucquote}"
-    jq   = "{price: .[0].last|tonumber, time: .[0].timestamp|strptime(\"%Y-%m-%dT%H:%M:%S.%jZ\")|mktime, volume: .[0].volumeQuote|tonumber}"
+    jq   = "{price: .[0].last|tonumber, time: .[0].timestamp|strptime(\"%Y-%m-%dT%H:%M:%S.%fZ\")|mktime, volume: .[0].volumeQuote|tonumber}"
   }
 
   origin "huobi" {


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Service                  | (gofer)
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | Bug Fix
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | No
| Documentation PR         | `[skip-ci]`
| Any Dependency Changes?  | No
| License                  | AGPL

### description of pull request:

The `hitbtc` JQ query string looks to be incorrect, and silently passing incorrect values through the rest of the code. This results in undefined behavior, notably when determining the expiry time for the `hitbtc` results for a price-pair.

The [current query][ref-1] looks as follows: `"{price: .[0].last|tonumber, time: .[0].timestamp|strptime(\"%Y-%m-%dT%H:%M:%S.%jZ\")|mktime, volume: .[0].volumeQuote|tonumber}"` 

[ref-1]: https://github.com/chronicleprotocol/oracle-suite/blob/0e579fed4932754b7219884adf423688b9bd0baf/config/config-gofer.hcl#L79

`%j` stands for day of the year, zero-padded number, but the value seems to be decimal seconds `.000`. So `%j` should be replaced with: `%f` (Microsecond as a decimal number, zero-padded on the left).

I am also happy with the solution: `.timestamp | split(".")[0] | strptime("%Y-%m-%dT%H:%M:%S")` also shown in the example below. 

I am not sure if `gojq` should be as flexible on the pattern here as it is, I haven't followed up with a question there, but the test code below will output the following. NB. correct values are shown using the corrected JQ string.

```text
./jqtest 
2023/11/10 17:04:25 Query: .timestamp | strptime("%Y-%m-%dT%H:%M:%S.%jZ")
[]interface {}{2023, 10, 30, 15, 30, 4, 4, 333}
[]interface {}{2023, 1, 26, 15, 30, 18, 0, 56}
[]interface {}{2024, 10, 3, 15, 30, 27, 0, 307}
[]interface {}{2025, 8, 15, 15, 30, 36, 1, 257}
[]interface {}{2023, 0, 28, 14, 4, 21, 6, 27}
[]interface {}{2023, 2, 18, 15, 37, 54, 6, 76}
[]interface {}{2024, 4, 10, 15, 38, 5, 5, 130}
2023/11/10 17:04:25 Query: .timestamp | strptime("%Y-%m-%dT%H:%M:%S.%fZ")
[]interface {}{2023, 10, 10, 15, 30, 4.33400011, 5, 313}
[]interface {}{2023, 10, 10, 15, 30, 18.056999921, 5, 313}
[]interface {}{2023, 10, 10, 15, 30, 27.673000097, 5, 313}
[]interface {}{2023, 10, 10, 15, 30, 36.989000082, 5, 313}
[]interface {}{2023, 10, 10, 14, 4, 21.028000116, 5, 313}
[]interface {}{2023, 10, 10, 15, 37, 54.076999902, 5, 313}
[]interface {}{2023, 10, 10, 15, 38, 5.496000051, 5, 313}
2023/11/10 17:04:25 Query: .timestamp | split(".")[0] | strptime("%Y-%m-%dT%H:%M:%S")
[]interface {}{2023, 10, 10, 15, 30, 4, 5, 313}
[]interface {}{2023, 10, 10, 15, 30, 18, 5, 313}
[]interface {}{2023, 10, 10, 15, 30, 27, 5, 313}
[]interface {}{2023, 10, 10, 15, 30, 36, 5, 313}
[]interface {}{2023, 10, 10, 14, 4, 21, 5, 313}
[]interface {}{2023, 10, 10, 15, 37, 54, 5, 313}
[]interface {}{2023, 10, 10, 15, 38, 5, 5, 313}
```

```golang
package main

import (
	"fmt"
	"log"

	"github.com/itchyny/gojq"
)

func main() {

	testDates := []string{
		"2023-11-10T15:30:04.334Z",
		"2023-11-10T15:30:18.057Z",
		"2023-11-10T15:30:27.673Z",
		"2023-11-10T15:30:36.989Z",
		"2023-11-10T14:04:21.028Z",
		"2023-11-10T15:37:54.077Z",
		"2023-11-10T15:38:05.496Z",
	}

	testQueries := []string{
		// Current JQ: https://github.com/chronicleprotocol/oracle-suite/blob/0e579fed4932754b7219884adf423688b9bd0baf/config/config-gofer.hcl#L79
		".timestamp | strptime(\"%Y-%m-%dT%H:%M:%S.%jZ\")",
		// Correct JQ: '%f'.
		".timestamp | strptime(\"%Y-%m-%dT%H:%M:%S.%fZ\")",
		// Other potential solution.
		".timestamp | split(\".\")[0] | strptime(\"%Y-%m-%dT%H:%M:%S\")",
	}

	for _, pattern := range testQueries {

		log.Println("Query:", pattern)

		for _, date := range testDates {

			query, err := gojq.Parse(pattern)
			if err != nil {
				log.Fatalln(err)
			}
			input := map[string]any{"timestamp": date}
			iter := query.Run(input) // or query.RunWithContext
			for {
				v, ok := iter.Next()
				if !ok {
					break
				}
				if err, ok := v.(error); ok {
					log.Println(err)
				}
				fmt.Printf("%#v\n", v)
			}
		}
	}
}
```

-