### PR TITLE
Remove pre-commit and GitHub workflow artefacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Oracle Suite
 
-[![Run Tests](https://github.com/chronicleprotocol/oracle-suite/actions/workflows/test.yml/badge.svg)](https://github.com/chronicleprotocol/oracle-suite/actions/workflows/test.yml)
-[![Release Assets](https://github.com/chronicleprotocol/oracle-suite/actions/workflows/release.yml/badge.svg)](https://github.com/chronicleprotocol/oracle-suite/actions/workflows/release.yml)
-
 A set of tools that can be used to run Oracles.
 
 ## Gofer
@@ -28,57 +25,3 @@ see: [Ghost CLI Readme](cmd/ghost/README.md)
 A tool used by relays to update Oracle contracts.
 
 see: [Spectre CLI Readme](cmd/spectre/README.md)
-
-
-## Setup pre-commit hooks
-
-### Install pre-commit
-
-Using homebrew:
-```bash
-$ brew install pre-commit
-```
-
-Using pip:
-```bash
-$ pip install pre-commit
-```
-
-Check pre-commit version
-```bash
-$ pre-commit --version
-pre-commit 3.3.3
-```
-
-### Configure .pre-commit-config.yaml
-- You can create a file named `.pre-commit-config.yaml`
-- You can generate a very basic configuration using `pre-commit sample-config`
-- Or you can directly use [`.pre-commit-config.yaml`](https://github.com/chronicleprotocol/oracle-suite/.pre-commit-hooks.yaml) file in the repository
-
-Example:
-```editorconfig
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
-repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
-    hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-    -   id: check-added-large-files
-```
-
-### Install git hook scripts
-Run `pre-commit install` to set up the git hooks scripts
-```bash
-$ pre-commit install
-pre-commit installed at .git/hooks/pre-commit
-```
-
-Now you're ready to `git commit`!
-
-### Run all the files (optional)
-```bash
-pre-commit run --all-files
-```


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Service                  | project-level
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | Fix
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Tests Added + Pass?      | n/a
| Documentation PR         | `[skip-ci]`
| Any Dependency Changes?  | No
| License                  | AGPL

### description of pull request:

Following https://github.com/chronicleprotocol/oracle-suite/commit/e8496ae9e621c9a9f5f94b3c96704f4da7f550f4 these documentation components around pre-commit or GitHub workflows look to be no-longer needed.

Just a quick question to the team, but will you be replacing the linting components with anything? -- I just happened to be looking at the CI workflow today (it looks like golangci-lint hadn't been working for a while) so these commits triggered my antennae. Any public-facing CI capability is helpful. 

---